### PR TITLE
Make usage of configs more flexible for extra ignores

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -20,13 +20,13 @@ def cli():
         "--private-files", metavar="PATH", nargs="+", help="All private files of the target under inspection."
     )
     parser.add_argument(
-        "--headers-info", metavar="PATH", help="Json file containing informations about all relevant header files."
+        "--headers-info", metavar="PATH", help="Json file containing information about all relevant header files."
     )
     parser.add_argument("--report", metavar="FILE", help="Report result into this file.")
     parser.add_argument(
         "--config",
         metavar="FILE",
-        help="Config file in Json fomrat overriting the attributes '--ignore-include-paths' and '--extra-ignore-include-paths'.",
+        help="Config file in Json format overriting the attributes '--ignore-include-paths' and '--extra-ignore-include-paths'.",
     )
     parser.add_argument(
         "--implementation-deps-available",
@@ -63,16 +63,17 @@ def cli():
 
 
 def _get_ignored_includes(args: Any) -> set:
-    if args.config:
-        ignored_includes, extra_ignored_includes = load_config(Path(args.config))
-        ignored_includes += extra_ignored_includes
-        return set(ignored_includes)
-
     ignored_includes = STD_HEADER if not args.ignore_include_paths else {args.ignore_include_paths}
-    if args.extra_ignore_include_paths:
-        ignored_includes += {args.extra_ignore_include_paths}
+    extra_ignored_includes = {args.extra_ignore_include_paths} if args.extra_ignore_include_paths else {}
 
-    return ignored_includes
+    if args.config:
+        config_ignored_includes, config_extra_ignored_includes = load_config(Path(args.config))
+        if config_ignored_includes:
+            ignored_includes = set(config_ignored_includes)
+        if config_extra_ignored_includes:
+            extra_ignored_includes = set(config_extra_ignored_includes)
+
+    return ignored_includes.union(extra_ignored_includes)
 
 
 def main(args: Any) -> int:

--- a/test/custom_config/BUILD
+++ b/test/custom_config/BUILD
@@ -1,11 +1,23 @@
-filegroup(
-    name = "custom_config",
-    srcs = ["custom_config.json"],
-    visibility = ["//visibility:public"],
+exports_files([
+    "extra_ignore_include_paths.json",
+    "full_custom_config.json",
+    "ignore_include_paths.json",
+])
+
+# Has an invalid include besides a standard include, which does however not cause an error due to the ignore list in the config
+cc_library(
+    name = "use_arcane_header_and_vector",
+    hdrs = ["use_arcane_header_and_vector.h"],
 )
 
-# Has an invalid include, which does however not cause an error due to the ognore list in the config
+# Has an invalid include, which does however not cause an error due to the ignore list in the config
 cc_library(
-    name = "foo",
-    hdrs = ["foo.h"],
+    name = "use_arcane_header",
+    hdrs = ["use_arcane_header.h"],
+)
+
+# Has multiple invalid includes, which do however not cause an error due to the ignore lists in the config
+cc_library(
+    name = "use_multiple_arcane_headers",
+    hdrs = ["use_multiple_arcane_headers.h"],
 )

--- a/test/custom_config/aspect.bzl
+++ b/test/custom_config/aspect.bzl
@@ -1,3 +1,5 @@
 load("//:defs.bzl", "dwyu_aspect_factory")
 
-custom_config_aspect = dwyu_aspect_factory(config = "//test/custom_config")
+full_custom_config_aspect = dwyu_aspect_factory(config = "//test/custom_config:full_custom_config.json")
+ignore_include_paths_aspect = dwyu_aspect_factory(config = "//test/custom_config:ignore_include_paths.json")
+extra_ignore_include_paths_aspect = dwyu_aspect_factory(config = "//test/custom_config:extra_ignore_include_paths.json")

--- a/test/custom_config/extra_ignore_include_paths.json
+++ b/test/custom_config/extra_ignore_include_paths.json
@@ -1,0 +1,6 @@
+{
+    "ignore_include_paths": [],
+    "extra_ignore_include_paths": [
+        "some_arcane_header.h"
+    ]
+}

--- a/test/custom_config/full_custom_config.json
+++ b/test/custom_config/full_custom_config.json
@@ -1,0 +1,8 @@
+{
+    "ignore_include_paths": [
+        "some_arcane_header_a.h"
+    ],
+    "extra_ignore_include_paths": [
+        "some_arcane_header_b.h"
+    ]
+}

--- a/test/custom_config/ignore_include_paths.json
+++ b/test/custom_config/ignore_include_paths.json
@@ -1,6 +1,6 @@
 {
     "ignore_include_paths": [
-        "some_arcane_header.h"
+        "some_arcane_header"
     ],
     "extra_ignore_include_paths": []
 }

--- a/test/custom_config/use_arcane_header.h
+++ b/test/custom_config/use_arcane_header.h
@@ -1,0 +1,1 @@
+#include <some_arcane_header>

--- a/test/custom_config/use_arcane_header_and_vector.h
+++ b/test/custom_config/use_arcane_header_and_vector.h
@@ -1,1 +1,2 @@
 #include "some_arcane_header.h"
+#include <vector>

--- a/test/custom_config/use_multiple_arcane_headers.h
+++ b/test/custom_config/use_multiple_arcane_headers.h
@@ -1,0 +1,2 @@
+#include "some_arcane_header_a.h"
+#include "some_arcane_header_b.h"

--- a/test/execute_tests.py
+++ b/test/execute_tests.py
@@ -29,8 +29,27 @@ DEFAULT_ASPECT = "//test:aspect.bzl%dwyu_default_aspect"
 
 TESTS = [
     TestCase(
-        name="custom_config",
-        cmd=TestCmd(target="//test/custom_config:foo", aspect="//test/custom_config:aspect.bzl%custom_config_aspect"),
+        name="custom_config_full",
+        cmd=TestCmd(
+            target="//test/custom_config:use_multiple_arcane_headers",
+            aspect="//test/custom_config:aspect.bzl%full_custom_config_aspect",
+        ),
+        expected=ExpectedResult(success=True),
+    ),
+    TestCase(
+        name="custom_config_extra_ignore_include_paths",
+        cmd=TestCmd(
+            target="//test/custom_config:use_arcane_header_and_vector",
+            aspect="//test/custom_config:aspect.bzl%extra_ignore_include_paths_aspect",
+        ),
+        expected=ExpectedResult(success=True),
+    ),
+    TestCase(
+        name="custom_config_ignore_include_paths",
+        cmd=TestCmd(
+            target="//test/custom_config:use_arcane_header",
+            aspect="//test/custom_config:aspect.bzl%ignore_include_paths_aspect",
+        ),
         expected=ExpectedResult(success=True),
     ),
     TestCase(


### PR DESCRIPTION
Allow specifying extra ignored include dirs without overwriting the
default ignore directories.

Resolves: https://github.com/martis42/depend_on_what_you_use/issues/21