### PR TITLE
Added pre-commit checks to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,14 @@ name: CI
 on: [push, pull_request]
 
 jobs:
+  pre-commit:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - uses: snok/install-poetry@v1
+      - uses: pre-commit/action@v2.0.3
+
   tests:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,20 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
       - uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          installer-parallel: true
+      - name: Load cached venv
+        id: cached-poetry-dependencies
+        uses: actions/cache@v2
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
+      - name: Install dependencies
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        run: poetry install --no-interaction --no-root
+      - run: source .venv/bin/activate
       - uses: pre-commit/action@v2.0.3
 
   tests:


### PR DESCRIPTION
pre-commit checks are executed as a dedicated job parallel to the `test` job.
Just in case that the user forgets about local execution, it's good that the CI checks in parallel.

From
* https://github.com/snok/install-poetry#workflow-examples-and-tips
* https://github.com/pre-commit/action#using-this-action