### PR TITLE
[AnalyzeIncludes]: bugfix for to_json method of Report

### DIFF
--- a/src/analyze_includes/evaluate_includes.py
+++ b/src/analyze_includes/evaluate_includes.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from dataclasses import dataclass, field
 from json import dumps
 from pathlib import Path
@@ -44,9 +45,12 @@ class Result:
         return self._framed_msg(msg)
 
     def to_json(self) -> str:
+        invalid_includes_mapping = defaultdict(list)
+        for x in self.invalid_includes:
+            invalid_includes_mapping[str(x.file)].append(x.include)
         content = {
             "analyzed_target": self.target,
-            "invalid_includes": {str(x.file): x.include for x in self.invalid_includes},
+            "invalid_includes": invalid_includes_mapping,
             "unused_dependencies": self.unused_deps,
             "deps_which_should_be_private": self.deps_which_should_be_private,
         }

--- a/src/analyze_includes/test/evaluate_includes_test.py
+++ b/src/analyze_includes/test/evaluate_includes_test.py
@@ -1,3 +1,4 @@
+import json
 import unittest
 from pathlib import Path
 
@@ -87,6 +88,16 @@ class TestResult(unittest.TestCase):
         )
         self.assertEqual(unit.to_json(), self._expected_json(target="//foo:bar", should_be_private_error='"foo"'))
 
+    def test_to_json_of_invalid_includes(self):
+        unit = Result(target="//foo:bar", invalid_includes = [
+            Include(file=Path("foo"), include = "dog.h"),
+            Include(file=Path("bar"), include = "cat.h"),
+            Include(file=Path("bar"), include = "dog.h")
+        ])
+        restored_unit = json.loads(unit.to_json())
+        invalid_includes = restored_unit["invalid_includes"]
+        self.assertEqual(len(invalid_includes), 2)
+        self.assertEqual(len(invalid_includes["bar"]), 2)
 
 class TestEvaluateIncludes(unittest.TestCase):
     def test_success_for_valid_external_dependencies(self):


### PR DESCRIPTION
The `to_str` and `to_json` methods of `Report` returned different result for `invalid_includes`, and it turns out to be a bug in the `to_json` method of `Report`. This PR attempts to fix this. 
