### PR TITLE
Distinguish between invalid public and private includes

### DIFF
--- a/src/analyze_includes/evaluate_includes.py
+++ b/src/analyze_includes/evaluate_includes.py
@@ -64,8 +64,8 @@ class Result:
             "analyzed_target": self.target,
             "public_includes_without_dep": self._make_includes_map(self.public_includes_without_dep),
             "private_includes_without_dep": self._make_includes_map(self.private_includes_without_dep),
-            "unused_public_dependencies": self.unused_public_deps,
-            "unused_private_dependencies": self.unused_private_deps,
+            "unused_public_deps": self.unused_public_deps,
+            "unused_private_deps": self.unused_private_deps,
             "deps_which_should_be_private": self.deps_which_should_be_private,
         }
         return dumps(content, indent=2) + "\n"

--- a/src/analyze_includes/test/evaluate_includes_test.py
+++ b/src/analyze_includes/test/evaluate_includes_test.py
@@ -33,8 +33,8 @@ class TestResult(unittest.TestCase):
   "analyzed_target": "//foo:bar",
   "public_includes_without_dep": {},
   "private_includes_without_dep": {},
-  "unused_public_dependencies": [],
-  "unused_private_dependencies": [],
+  "unused_public_deps": [],
+  "unused_private_deps": [],
   "deps_which_should_be_private": []
 }
 """.lstrip(),
@@ -76,8 +76,8 @@ class TestResult(unittest.TestCase):
       "missing_3"
     ]
   },
-  "unused_public_dependencies": [],
-  "unused_private_dependencies": [],
+  "unused_public_deps": [],
+  "unused_private_deps": [],
   "deps_which_should_be_private": []
 }
 """.lstrip(),
@@ -119,8 +119,8 @@ class TestResult(unittest.TestCase):
     ]
   },
   "private_includes_without_dep": {},
-  "unused_public_dependencies": [],
-  "unused_private_dependencies": [],
+  "unused_public_deps": [],
+  "unused_private_deps": [],
   "deps_which_should_be_private": []
 }
 """.lstrip(),
@@ -146,11 +146,11 @@ class TestResult(unittest.TestCase):
   "analyzed_target": "//foo:bar",
   "public_includes_without_dep": {},
   "private_includes_without_dep": {},
-  "unused_public_dependencies": [
+  "unused_public_deps": [
     "foo",
     "baz"
   ],
-  "unused_private_dependencies": [],
+  "unused_private_deps": [],
   "deps_which_should_be_private": []
 }
 """.lstrip(),
@@ -176,8 +176,8 @@ class TestResult(unittest.TestCase):
   "analyzed_target": "//foo:bar",
   "public_includes_without_dep": {},
   "private_includes_without_dep": {},
-  "unused_public_dependencies": [],
-  "unused_private_dependencies": [
+  "unused_public_deps": [],
+  "unused_private_deps": [
     "foo",
     "baz"
   ],
@@ -207,10 +207,10 @@ class TestResult(unittest.TestCase):
   "analyzed_target": "//foo:bar",
   "public_includes_without_dep": {},
   "private_includes_without_dep": {},
-  "unused_public_dependencies": [
+  "unused_public_deps": [
     "foo"
   ],
-  "unused_private_dependencies": [
+  "unused_private_deps": [
     "baz"
   ],
   "deps_which_should_be_private": []
@@ -238,8 +238,8 @@ class TestResult(unittest.TestCase):
   "analyzed_target": "//foo:bar",
   "public_includes_without_dep": {},
   "private_includes_without_dep": {},
-  "unused_public_dependencies": [],
-  "unused_private_dependencies": [],
+  "unused_public_deps": [],
+  "unused_private_deps": [],
   "deps_which_should_be_private": [
     "foo",
     "baz"

--- a/src/apply_fixes/main.py
+++ b/src/apply_fixes/main.py
@@ -181,8 +181,8 @@ def perform_fixes(workspace: Path, report: Path, buildozer: str, buildozer_args:
     with open(report, encoding="utf-8") as report_in:
         content = json.load(report_in)
         target = content["analyzed_target"]
-        unused_public_deps = content["unused_public_dependencies"]
-        unused_private_deps = content["unused_private_dependencies"]
+        unused_public_deps = content["unused_public_deps"]
+        unused_private_deps = content["unused_private_deps"]
         deps_which_should_be_private = content["deps_which_should_be_private"]
 
         base_cmd = make_base_cmd(buildozer=buildozer, buildozer_args=buildozer_args, dry=dry)


### PR DESCRIPTION
We want to offer an automatic fix for invalid includes, where we search for a dependency which provides the header used in the target sources.
To be able to add the dependency correctly to either `deps` or `implementation_deps` we have to 