### PR TITLE
Test: Fix the complex_includes testcase

### DIFF
--- a/test/aspect/complex_includes/BUILD
+++ b/test/aspect/complex_includes/BUILD
@@ -18,6 +18,6 @@ cc_library(
 
 cc_library(
     name = "use_complex_includes_from_extern",
-    srcs = ["use_complex_includes_from_extern.cpp"],
+    srcs = ["use_complex_includes.cpp"],
     deps = ["@complex_includes_repo//:complex_includes"],
 )

--- a/test/aspect/execute_tests.py
+++ b/test/aspect/execute_tests.py
@@ -171,13 +171,13 @@ TESTS = [
     TestCase(
         name="complex_includes",
         compatible_versions=CompatibleVersions(min="4.1.0"),  # Does not compile with 4.0.0
-        cmd=TestCmd(target="//test/aspect/complex_includes:all"),
+        cmd=TestCmd(target="//test/aspect/complex_includes:all", aspect=DEFAULT_ASPECT),
         expected=ExpectedResult(success=True),
     ),
     TestCase(
         name="complex_includes_in_ext_repo",
         compatible_versions=CompatibleVersions(min="4.1.0"),  # Does not compile with 4.0.0
-        cmd=TestCmd(target="@complex_includes_repo//..."),
+        cmd=TestCmd(target="@complex_includes_repo//...", aspect=DEFAULT_ASPECT),
         expected=ExpectedResult(success=True),
     ),
     TestCase(


### PR DESCRIPTION
This PR attempts to fix the otherwise failing `//test/aspect/complex_includes:use_complex_includes_from_extern` case
when running from command line. 
