### PR TITLE
Fix aspect test case

### DIFF
--- a/test/aspect/execute_tests.py
+++ b/test/aspect/execute_tests.py
@@ -182,7 +182,7 @@ TESTS = [
     ),
     TestCase(
         name="incompatible_platforms",
-        cmd=TestCmd(target="//test/aspect/platforms/..."),
+        cmd=TestCmd(target="//test/aspect/platforms/...", aspect=DEFAULT_ASPECT),
         expected=ExpectedResult(success=True),
     ),
     TestCase(


### PR DESCRIPTION
Without providing an aspect only a normal bazel is executed and no DWYU aspect is executed.