### PR TITLE
Test: make include path relative to the workspace directory

### DIFF
--- a/test/aspect/valid/bar/bar.cc
+++ b/test/aspect/valid/bar/bar.cc
@@ -1,6 +1,7 @@
-#include "private_a.h"
-#include "sub/dir/private_b.h"
 #include "test/aspect/valid/bar/bar.h"
+
+#include "test/aspect/valid/bar/private_a.h"
+#include "test/aspect/valid/bar/sub/dir/private_b.h"
 #include "test/aspect/valid/foo/b.h"
 #include "test/aspect/valid/foo/textual.cc"
 


### PR DESCRIPTION
According to https://bazel.build/docs/bazel-and-cpp#include-paths, all include paths should be relative to the workspace directory if possible. 
