### PR TITLE
Use `re.match(pattern, include)` for ignored include patterns

### DIFF
--- a/src/analyze_includes/parse_source.py
+++ b/src/analyze_includes/parse_source.py
@@ -35,7 +35,7 @@ class IgnoredIncludes:
 
     def is_ignored(self, include: str) -> bool:
         is_ignored_path = include in self.paths
-        is_ignored_pattern = any(re.search(pattern, include) for pattern in self.patterns)
+        is_ignored_pattern = any(re.match(pattern, include) for pattern in self.patterns)
         return is_ignored_path or is_ignored_pattern
 
 

--- a/src/analyze_includes/test/parse_source_test.py
+++ b/src/analyze_includes/test/parse_source_test.py
@@ -52,7 +52,7 @@ class TestFilterIncludes(unittest.TestCase):
             includes=[
                 Include(file=Path("file1"), include="hiho.h"),
                 Include(file=Path("file2"), include="foo"),
-                Include(file=Path("file3"), include="foo_no_substring_match"),
+                Include(file=Path("file3"), include="foo_pattern_not_match"),
                 Include(file=Path("file4"), include="some/other/baz.h"),
                 Include(file=Path("file5"), include="bar/baz.h"),
             ],
@@ -61,7 +61,7 @@ class TestFilterIncludes(unittest.TestCase):
 
         self.assertEqual(len(result), 3)
         self.assertTrue(Include(file=Path("file1"), include="hiho.h") in result)
-        self.assertTrue(Include(file=Path("file3"), include="foo_no_substring_match") in result)
+        self.assertTrue(Include(file=Path("file3"), include="foo_pattern_not_match") in result)
         self.assertTrue(Include(file=Path("file4"), include="some/other/baz.h") in result)
 
     def test_filter_includes_for_patterns(self):
@@ -72,14 +72,15 @@ class TestFilterIncludes(unittest.TestCase):
                 Include(file=Path("file3"), include="foo/bar.h"),
                 Include(file=Path("file4"), include="foo/nested/bar.h"),
                 Include(file=Path("file4"), include="baz_some_partial_name.h"),
-                Include(file=Path("file5"), include="match_substring"),
+                Include(file=Path("file5"), include="match_substring_not_sufficient"),
             ],
             ignored_includes=IgnoredIncludes(paths=[], patterns=["foo/.*", ".*some_partial_name.h", "substring"]),
         )
 
-        self.assertEqual(len(result), 2)
+        self.assertEqual(len(result), 3)
         self.assertTrue(Include(file=Path("file1"), include="hiho.h") in result)
         self.assertTrue(Include(file=Path("file2"), include="foo.h") in result)
+        self.assertTrue(Include(file=Path("file5"), include="match_substring_not_sufficient") in result)
 
 
 class TestGetIncludesFromFile(unittest.TestCase):

--- a/test/aspect/custom_config/ignore_include_patterns.json
+++ b/test/aspect/custom_config/ignore_include_patterns.json
@@ -2,6 +2,6 @@
     "ignore_include_patterns": [
         "foo/.*",
         "bar/.*",
-        "./ignored_sub_path/.*"
+        "\\w+/ignored_sub_path/.*"
     ]
 }


### PR DESCRIPTION
If instead we use `re.search(pattern, include)`, include `baz/a/b.h` will be matched against pattern `a/.*`, which should be an unexpected behavior.