### PR TITLE
Fix regression for relative includes to own private headers

### DIFF
--- a/test/aspect/relative_includes/BUILD
+++ b/test/aspect/relative_includes/BUILD
@@ -1,21 +1,25 @@
 cc_library(
     name = "normal_include",
-    srcs = ["normal_include.cpp"],
+    srcs = [
+        "normal_include.cpp",
+        "some/sub/dir2/baz.h",
+    ],
     hdrs = [
         "normal_include.h",
         "some/sub/dir/bar.h",
         "some/sub/dir/foo.h",
-        "some/sub/dir2/baz.h",
     ],
 )
 
 cc_library(
     name = "system_include",
-    srcs = ["system_include.cpp"],
+    srcs = [
+        "some/sub/dir2/baz.h",
+        "system_include.cpp",
+    ],
     hdrs = [
         "some/sub/dir/bar.h",
         "some/sub/dir/foo.h",
-        "some/sub/dir2/baz.h",
         "system_include.h",
     ],
     includes = ["some"],
@@ -23,7 +27,10 @@ cc_library(
 
 cc_library(
     name = "virtual_strip",
-    srcs = ["virtual_strip.cpp"],
+    srcs = [
+        "other/other.h",
+        "virtual_strip.cpp",
+    ],
     hdrs = [
         "some/sub/dir/bar.h",
         "some/sub/dir/foo.h",
@@ -35,7 +42,10 @@ cc_library(
 
 cc_library(
     name = "virtual_prefix",
-    srcs = ["virtual_prefix.cpp"],
+    srcs = [
+        "other/other.h",
+        "virtual_prefix.cpp",
+    ],
     hdrs = [
         "some/sub/dir/bar.h",
         "some/sub/dir/foo.h",

--- a/test/aspect/relative_includes/other/other.h
+++ b/test/aspect/relative_includes/other/other.h
@@ -1,0 +1,8 @@
+#ifndef OTHER_H
+#define OTHER_H
+
+int doOther() {
+    return 123;
+}
+
+#endif

--- a/test/aspect/relative_includes/use_normal_include.cpp
+++ b/test/aspect/relative_includes/use_normal_include.cpp
@@ -1,8 +1,8 @@
 // relative includes to headers from dependencies
 #include "normal_include.h"
 #include "some/sub/dir/foo.h"
-#include "some/sub/dir/../dir2/baz.h"
+#include "some/sub/dir/../dir/bar.h"
 
 int main() {
-    return useNormalInclude() + doBar() + doBaz();
+    return useNormalInclude() + doBar() + doFoo();
 }

--- a/test/aspect/relative_includes/use_system_include.cpp
+++ b/test/aspect/relative_includes/use_system_include.cpp
@@ -1,10 +1,10 @@
-// relatively including header from own target
+// relative includes to headers from dependencies
 #include "system_include.h"
 #include "some/sub/dir/foo.h"
-#include "some/sub/dir/../dir2/baz.h"
+#include "some/sub/dir/../dir/bar.h"
 // include from virtually prefixed path
 #include <sub/dir/bar.h>
 
 int main() {
-    return useSystemInclude() + doBar() + doBaz();
+    return useSystemInclude() + doBar() + doFoo();
 }

--- a/test/aspect/relative_includes/use_virtual_prefix.cpp
+++ b/test/aspect/relative_includes/use_virtual_prefix.cpp
@@ -1,10 +1,10 @@
-// relatively including header from own target
+// relative includes to headers from dependencies
 #include "virtual_prefix.h"
 #include "some/sub/dir/bar.h"
-#include "some/sub/dir/../dir2/baz.h"
+#include "some/sub/dir/../dir/bar.h"
 // include from virtually prefixed path
 #include "custom/prefix/some/sub/dir/foo.h"
 
 int main() {
-    return useVirtualPrefix() + doBar() + doBaz();
+    return useVirtualPrefix() + doBar() + doFoo();
 }

--- a/test/aspect/relative_includes/use_virtual_strip.cpp
+++ b/test/aspect/relative_includes/use_virtual_strip.cpp
@@ -1,10 +1,10 @@
-// relatively including header from own target
+// relative includes to headers from dependencies
 #include "some/virtual_strip.h"
 #include "some/sub/dir/bar.h"
-#include "some/sub/dir/../dir2/baz.h"
+#include "some/sub/dir/../dir/bar.h"
 // include from virtually stripped path
 #include "sub/dir/foo.h"
 
 int main() {
-    return useVirtualStrip() + doBar() + doBaz();
+    return useVirtualStrip() + doBar() + doFoo();
 }

--- a/test/aspect/relative_includes/virtual_prefix.cpp
+++ b/test/aspect/relative_includes/virtual_prefix.cpp
@@ -1,9 +1,10 @@
 // relatively including header from own target
 #include "virtual_prefix.h"
 #include "some/sub/dir/bar.h"
+#include "other/other.h"
 // include from virtually prefixed path
 #include "custom/prefix/some/sub/dir/foo.h"
 
 int useVirtualPrefix() {
-    return doFoo() + doBar();
+    return doFoo() + doBar() + doOther();
 }

--- a/test/aspect/relative_includes/virtual_strip.cpp
+++ b/test/aspect/relative_includes/virtual_strip.cpp
@@ -1,9 +1,10 @@
 // relatively including header from own target
 #include "some/virtual_strip.h"
 #include "some/sub/dir/bar.h"
+#include "other/other.h"
 // include from virtually stripped path
 #include "sub/dir/foo.h"
 
 int useVirtualStrip() {
-    return doFoo() + doBar();
+    return doFoo() + doBar() + doOther();
 }


### PR DESCRIPTION
For the target under inspection we have to incorporate headers from 'srcs' for the relative includes logic. In contrast to dependencies, where we ignore headers from 'srcs'.

Fix https://github.com/martis42/depend_on_what_you_use/issues/100