### PR TITLE
Use pcpp to parse C/C++ source code

### DIFF
--- a/src/analyze_includes/BUILD
+++ b/src/analyze_includes/BUILD
@@ -1,3 +1,4 @@
+load("@dwyu_py_deps//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 
 py_library(
@@ -10,6 +11,7 @@ py_library(
         "system_under_inspection.py",
     ],
     visibility = [":__subpackages__"],
+    deps = [requirement("pcpp")],
 )
 
 py_binary(

--- a/src/analyze_includes/test/BUILD
+++ b/src/analyze_includes/test/BUILD
@@ -26,6 +26,7 @@ py_test(
         "data/commented_includes/block_comments.h",
         "data/commented_includes/mixed_style.h",
         "data/commented_includes/single_line_comments.h",
+        "data/empty_header.h",
         "data/some_header.h",
     ],
     deps = ["//src/analyze_includes:lib"],

--- a/src/analyze_includes/test/parse_source_test.py
+++ b/src/analyze_includes/test/parse_source_test.py
@@ -98,6 +98,12 @@ class TestFilterIncludes(unittest.TestCase):
 
 
 class TestGetIncludesFromFile(unittest.TestCase):
+    def test_empty_header(self):
+        test_file = Path("src/analyze_includes/test/data/empty_header.h")
+        result = get_includes_from_file(test_file)
+
+        self.assertEqual(result, [])
+
     def test_single_include(self):
         test_file = Path("src/analyze_includes/test/data/another_header.h")
         result = get_includes_from_file(test_file)


### PR DESCRIPTION
In this first step we simplify our own code by using a well tested preprocessor to prune commented code instead of relying on our own implementation.
In the future we will build on this and support resolving defines