### PR TITLE
Add basic support for processing preprocessor defines

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,10 +15,9 @@ repos:
       # Python code quality
       - id: debug-statements
   - repo: https://github.com/executablebooks/mdformat
-    rev: 0.7.16  # Use the ref you want to point at
+    rev: 0.7.16
     hooks:
       - id: mdformat
-        # Optionally add plugins
         additional_dependencies:
           - mdformat-gfm
   - repo: https://github.com/keith/pre-commit-buildifier

--- a/README.md
+++ b/README.md
@@ -167,9 +167,11 @@ Examples for this can be seen at the [implementation_deps test cases](test/aspec
 ## Known limitations
 
 - If includes are added through a macro, this is invisible to DWYU.
-- Defines are ignored.
-  No matter if they are defined directly inside the header under inspection, headers from the dependencies or injected
-  through the `defines = [...]` attribute of the `cc_` rules.
+- Fundamental support for processing preprocessor defines is present.
+  However, if header A specifies a define X and is included in header B, header B is not aware of X from header A.
+  Right now only defines specified through Bazel (e.g. toolchain or `cc_*` target attributes) or defines specified
+  inside a file itself are used to process a file and discover include statements.
+  We aim to resolve this limitation in a future release.
 - Include statements utilizing `..` are not recognized if they are used on virtual or system include paths.
 
 ## Applying automatic fixes

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,9 +4,11 @@ load("//:setup_step_1.bzl", "setup_step_1")
 
 setup_step_1()
 
-load("//:setup_step_2.bzl", "setup_step_2")
+load("//:setup_step_2.bzl", "dev_setup_step_2", "setup_step_2")
 
 setup_step_2()
+
+dev_setup_step_2()
 
 load("//:setup_step_3.bzl", "setup_step_3")
 

--- a/setup_step_2.bzl
+++ b/setup_step_2.bzl
@@ -1,3 +1,4 @@
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 load("@bazel_skylib//lib:versions.bzl", "versions")
 load("//third_party:dependencies_step_2.bzl", "dependencies_step_2")
 
@@ -11,3 +12,9 @@ def setup_step_2():
     versions.check(
         minimum_bazel_version = "4.0.0",
     )
+
+def dev_setup_step_2():
+    """
+    Setup step required for development but of not interest for users.
+    """
+    bazel_skylib_workspace()

--- a/src/analyze_includes/evaluate_includes.py
+++ b/src/analyze_includes/evaluate_includes.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from json import dumps
 from pathlib import Path
-from typing import Any, DefaultDict, List, Optional
+from typing import DefaultDict, List, Optional
 
 from src.analyze_includes.parse_source import Include
 from src.analyze_includes.system_under_inspection import (
@@ -155,6 +155,7 @@ def _filter_empty_dependencies(system_under_inspection: SystemUnderInspection) -
     return SystemUnderInspection(
         public_deps=[pub for pub in system_under_inspection.public_deps if pub.include_paths],
         private_deps=[pri for pri in system_under_inspection.private_deps if pri.include_paths],
+        defines=system_under_inspection.defines,
         target_under_inspection=system_under_inspection.target_under_inspection,
     )
 

--- a/src/analyze_includes/main.py
+++ b/src/analyze_includes/main.py
@@ -44,18 +44,19 @@ def cli():
 
 def main(args: Namespace) -> int:
     ignored_includes = get_ignored_includes(args.ignored_includes_config)
+    system_under_inspection = get_system_under_inspection(args.headers_info)
 
     all_includes_from_public = get_relevant_includes_from_files(
-        files=args.public_files, ignored_includes=ignored_includes
+        files=args.public_files, ignored_includes=ignored_includes, defines=system_under_inspection.defines
     )
     all_includes_from_private = get_relevant_includes_from_files(
-        files=args.private_files, ignored_includes=ignored_includes
+        files=args.private_files, ignored_includes=ignored_includes, defines=system_under_inspection.defines
     )
 
     result = evaluate_includes(
         public_includes=all_includes_from_public,
         private_includes=all_includes_from_private,
-        system_under_inspection=get_system_under_inspection(args.headers_info),
+        system_under_inspection=system_under_inspection,
         ensure_private_deps=args.implementation_deps_available,
     )
 

--- a/src/analyze_includes/system_under_inspection.py
+++ b/src/analyze_includes/system_under_inspection.py
@@ -84,12 +84,15 @@ class SystemUnderInspection:
         self,
         public_deps: List[CcTarget],
         private_deps: List[CcTarget],
+        defines: List[str],
         target_under_inspection: CcTarget,
     ) -> None:
         # Dependencies which are available to downstream dependencies of the target under inspection
         self.public_deps = public_deps
         # Dependencies which are NOT available to downstream dependencies of the target under inspection
         self.private_deps = private_deps
+        # Defines influencing the preprocessor
+        self.defines = defines
         # Target under inspection
         self.target_under_inspection = target_under_inspection
 
@@ -111,5 +114,6 @@ def get_system_under_inspection(allowed_includes_file: Path) -> SystemUnderInspe
         return SystemUnderInspection(
             public_deps=[_make_cc_target(dep) for dep in loaded["public_deps"]],
             private_deps=[_make_cc_target(dep) for dep in loaded["private_deps"]],
+            defines=loaded["defines"],
             target_under_inspection=_make_cc_target(loaded["self"]),
         )

--- a/src/analyze_includes/test/BUILD
+++ b/src/analyze_includes/test/BUILD
@@ -27,6 +27,7 @@ py_test(
         "data/commented_includes/mixed_style.h",
         "data/commented_includes/single_line_comments.h",
         "data/empty_header.h",
+        "data/header_with_defines.h",
         "data/some_header.h",
     ],
     deps = ["//src/analyze_includes:lib"],

--- a/src/analyze_includes/test/data/header_with_defines.h
+++ b/src/analyze_includes/test/data/header_with_defines.h
@@ -1,0 +1,35 @@
+#define INTERNAL
+
+#ifdef INTERNAL
+#include "has_internal.h"
+#else
+#include "no_internal.h"
+#endif
+
+#ifdef FOO
+#include "has_foo.h"
+#else
+#include "no_foo.h"
+#endif
+
+/*
+#ifdef FOO
+#include "should_never_be_active_due_to_being_commented"
+#else
+#include "should_never_be_active_due_to_being_commented"
+#endif
+*/
+
+#ifndef BAR
+#include "no_bar.h"
+#else
+#include "has_bar.h"
+#endif
+
+#if BAZ > 40
+#include "baz_greater_40.h"
+#elif BAZ > 10
+#include "baz_greater_10.h"
+#else
+#include "no_baz.h"
+#endif

--- a/src/analyze_includes/test/data/headers_info_empty.json
+++ b/src/analyze_includes/test/data/headers_info_empty.json
@@ -1,6 +1,7 @@
 {
   "private_deps": [],
   "public_deps": [],
+  "defines": [],
   "self": {
     "include_paths": [],
     "header_files": [],

--- a/src/analyze_includes/test/data/headers_info_full.json
+++ b/src/analyze_includes/test/data/headers_info_full.json
@@ -47,6 +47,10 @@
       "target": "//public/dep:bar"
     }
   ],
+  "defines": [
+    "SOME_DEFINE",
+    "ANOTHER_DEFINE=42"
+  ],
   "self": {
     "include_paths": [
       "self/a.h",

--- a/src/analyze_includes/test/evaluate_includes_test.py
+++ b/src/analyze_includes/test/evaluate_includes_test.py
@@ -305,6 +305,7 @@ class TestEvaluateIncludes(unittest.TestCase):
                     self.make_cc_target(name="lib_without_hdrs_purely_for_linking", files=[]),
                 ],
                 private_deps=[self.make_cc_target(name="baz_pkg", files=["baz.h"])],
+                defines=[],
             ),
             ensure_private_deps=True,
         )
@@ -319,6 +320,7 @@ class TestEvaluateIncludes(unittest.TestCase):
                 target_under_inspection=self.make_cc_target(name="foo", files=["foo.h", "bar.h"]),
                 public_deps=[],
                 private_deps=[],
+                defines=[],
             ),
             ensure_private_deps=True,
         )
@@ -341,6 +343,7 @@ class TestEvaluateIncludes(unittest.TestCase):
                 ),
                 public_deps=[],
                 private_deps=[],
+                defines=[],
             ),
             ensure_private_deps=True,
         )
@@ -365,6 +368,7 @@ class TestEvaluateIncludes(unittest.TestCase):
                     )
                 ],
                 private_deps=[],
+                defines=[],
             ),
             ensure_private_deps=True,
         )
@@ -383,6 +387,7 @@ class TestEvaluateIncludes(unittest.TestCase):
                 ),
                 public_deps=[],
                 private_deps=[],
+                defines=[],
             ),
             ensure_private_deps=True,
         )
@@ -410,6 +415,7 @@ class TestEvaluateIncludes(unittest.TestCase):
                 target_under_inspection=self.make_cc_target(name="foo", files=[]),
                 public_deps=[self.make_cc_target(name="foo", files=["foo.h"])],
                 private_deps=[self.make_cc_target(name="bar", files=["bar.h"])],
+                defines=[],
             ),
             ensure_private_deps=True,
         )
@@ -441,6 +447,7 @@ class TestEvaluateIncludes(unittest.TestCase):
                     self.make_cc_target(name="impl_foo", files=["impl_dep_foo.h"]),
                     self.make_cc_target(name="impl_bar", files=["impl_dep_bar.h"]),
                 ],
+                defines=[],
             ),
             ensure_private_deps=True,
         )
@@ -471,6 +478,7 @@ class TestEvaluateIncludes(unittest.TestCase):
                     self.make_cc_target(name="bar", files=["impl_dep_bar.h"]),
                 ],
                 private_deps=[],
+                defines=[],
             ),
             ensure_private_deps=True,
         )
@@ -499,6 +507,7 @@ class TestEvaluateIncludes(unittest.TestCase):
                     self.make_cc_target(name="bar", files=["impl_dep_bar.h"]),
                 ],
                 private_deps=[],
+                defines=[],
             ),
             ensure_private_deps=False,
         )

--- a/src/analyze_includes/test/parse_source_test.py
+++ b/src/analyze_includes/test/parse_source_test.py
@@ -100,19 +100,19 @@ class TestFilterIncludes(unittest.TestCase):
 class TestGetIncludesFromFile(unittest.TestCase):
     def test_empty_header(self):
         test_file = Path("src/analyze_includes/test/data/empty_header.h")
-        result = get_includes_from_file(test_file)
+        result = get_includes_from_file(test_file, defines=[])
 
         self.assertEqual(result, [])
 
     def test_single_include(self):
         test_file = Path("src/analyze_includes/test/data/another_header.h")
-        result = get_includes_from_file(test_file)
+        result = get_includes_from_file(test_file, defines=[])
 
         self.assertEqual(result, [Include(file=test_file, include="foo/bar.h")])
 
     def test_multiple_includes(self):
         test_file = Path("src/analyze_includes/test/data/some_header.h")
-        result = get_includes_from_file(test_file)
+        result = get_includes_from_file(test_file, defines=[])
 
         self.assertEqual(len(result), 4)
         self.assertTrue(Include(file=test_file, include="bar.h") in result)
@@ -121,7 +121,7 @@ class TestGetIncludesFromFile(unittest.TestCase):
 
     def test_commented_includes_single_line_comments(self):
         test_file = Path("src/analyze_includes/test/data/commented_includes/single_line_comments.h")
-        result = get_includes_from_file(test_file)
+        result = get_includes_from_file(test_file, defines=[])
 
         self.assertEqual(len(result), 2)
         self.assertTrue(Include(file=test_file, include="active_a.h") in result)
@@ -129,7 +129,7 @@ class TestGetIncludesFromFile(unittest.TestCase):
 
     def test_commented_includes_block_comments(self):
         test_file = Path("src/analyze_includes/test/data/commented_includes/block_comments.h")
-        result = get_includes_from_file(test_file)
+        result = get_includes_from_file(test_file, defines=[])
 
         self.assertEqual(len(result), 8)
         self.assertTrue(Include(file=test_file, include="active_a.h") in result)
@@ -143,9 +143,19 @@ class TestGetIncludesFromFile(unittest.TestCase):
 
     def test_commented_includes_mixed_style(self):
         test_file = Path("src/analyze_includes/test/data/commented_includes/mixed_style.h")
-        result = get_includes_from_file(test_file)
+        result = get_includes_from_file(test_file, defines=[])
 
         self.assertEqual(result, [Include(file=test_file, include="active.h")])
+
+    def test_includes_selected_through_defines(self):
+        test_file = Path("src/analyze_includes/test/data/header_with_defines.h")
+        result = get_includes_from_file(test_file, defines=["FOO", "BAZ 42"])
+
+        self.assertEqual(len(result), 4)
+        self.assertTrue(Include(file=test_file, include="has_internal.h") in result)
+        self.assertTrue(Include(file=test_file, include="has_foo.h") in result)
+        self.assertTrue(Include(file=test_file, include="no_bar.h") in result)
+        self.assertTrue(Include(file=test_file, include="baz_greater_40.h") in result)
 
 
 class TestGetRelevantIncludesFromFiles(unittest.TestCase):
@@ -153,6 +163,7 @@ class TestGetRelevantIncludesFromFiles(unittest.TestCase):
         result = get_relevant_includes_from_files(
             files=["src/analyze_includes/test/data/some_header.h", "src/analyze_includes/test/data/another_header.h"],
             ignored_includes=IgnoredIncludes(paths=["vector"], patterns=[]),
+            defines=[],
         )
 
         self.assertEqual(len(result), 4)

--- a/src/analyze_includes/test/system_under_inspection_test.py
+++ b/src/analyze_includes/test/system_under_inspection_test.py
@@ -158,6 +158,8 @@ class TestGetSystemUnderInspection(unittest.TestCase):
             expected_files=["public/dep/bar_1.h", "public/dep/bar_2.h"],
         )
 
+        self.assertEqual(sui.defines, ["SOME_DEFINE", "ANOTHER_DEFINE=42"])
+
         self.check_target(
             actual=sui.target_under_inspection,
             expected_name="//:baz",

--- a/src/aspect/factory.bzl
+++ b/src/aspect/factory.bzl
@@ -24,7 +24,12 @@ def dwyu_aspect_factory(
     return aspect(
         implementation = dwyu_aspect_impl,
         attr_aspects = attr_aspects,
+        fragments = ["cpp"],
+        toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
         attrs = {
+            "_cc_toolchain": attr.label(
+                default = Label("@bazel_tools//tools/cpp:current_cc_toolchain"),
+            ),
             "_config": attr.label(
                 default = config,
                 allow_single_file = [".json"],

--- a/src/aspect/test/BUILD
+++ b/src/aspect/test/BUILD
@@ -1,0 +1,3 @@
+load(":dwyu_test.bzl", "dwyu_aspect_test_suite")
+
+dwyu_aspect_test_suite(name = "dwyu_aspect_tests")

--- a/src/aspect/test/dwyu_test.bzl
+++ b/src/aspect/test/dwyu_test.bzl
@@ -23,7 +23,11 @@ def _extract_defines_from_compiler_flags_test_impl(ctx):
     asserts.equals(env, ["Foo=42"], extract_defines_from_compiler_flags(["-UFoo", "-DFoo=42"]))
 
     # Define with complex value
-    asserts.equals(env, ["Foo=BAR=42"], extract_defines_from_compiler_flags(["-DFoo=BAR=42"]))
+    asserts.equals(
+        env,
+        ["Foo=BAR=42", "Tick 42", 'Riff "Raff"'],
+        extract_defines_from_compiler_flags(["-DFoo=BAR=42", "-DTick 42", '-DRiff "Raff"']),
+    )
 
     return unittest.end(env)
 

--- a/src/aspect/test/dwyu_test.bzl
+++ b/src/aspect/test/dwyu_test.bzl
@@ -1,0 +1,36 @@
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("//src/aspect:dwyu.bzl", "extract_defines_from_compiler_flags")
+
+def _extract_defines_from_compiler_flags_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    # Basic case
+    asserts.equals(env, ["Bar"], extract_defines_from_compiler_flags(["--foo", "-DBar", "whatever"]))
+
+    # Deduplicate defines
+    asserts.equals(env, ["Bar", "Foo"], extract_defines_from_compiler_flags(["-DBar", "-DBar", "-DFoo"]))
+
+    # Defines overwrite each other
+    asserts.equals(env, ["Foo=1337"], extract_defines_from_compiler_flags(["-DFoo", "-DFoo=42", "-DFoo=1337"]))
+
+    # Undefine another define
+    asserts.equals(env, ["Bar"], extract_defines_from_compiler_flags(["-DFoo", "-UFoo", "-DBar"]))
+
+    # Undefine another define with value
+    asserts.equals(env, [], extract_defines_from_compiler_flags(["-DFoo=42", "-UFoo"]))
+
+    # Define previously undefined value
+    asserts.equals(env, ["Foo=42"], extract_defines_from_compiler_flags(["-UFoo", "-DFoo=42"]))
+
+    # Define with complex value
+    asserts.equals(env, ["Foo=BAR=42"], extract_defines_from_compiler_flags(["-DFoo=BAR=42"]))
+
+    return unittest.end(env)
+
+extract_defines_from_compiler_flags_test = unittest.make(_extract_defines_from_compiler_flags_test_impl)
+
+def dwyu_aspect_test_suite(name):
+    unittest.suite(
+        name,
+        extract_defines_from_compiler_flags_test,
+    )

--- a/test/aspect/defines/BUILD
+++ b/test/aspect/defines/BUILD
@@ -1,0 +1,6 @@
+cc_library(
+    name = "in_file_defines",
+    hdrs = ["in_file_defines.h"],
+    deps = ["//test/aspect/defines/lib:a"],
+)
+

--- a/test/aspect/defines/BUILD
+++ b/test/aspect/defines/BUILD
@@ -4,3 +4,20 @@ cc_library(
     deps = ["//test/aspect/defines/lib:a"],
 )
 
+cc_library(
+    name = "defines_from_bazel_target",
+    hdrs = ["defines_from_bazel_target.h"],
+    copts = ["-DSOME_COPT 42"],
+    defines = ["SOME_DEFINE"],
+    local_defines = ["LOCAL_DEFINE"],
+    deps = ["//test/aspect/defines/lib:a"],
+)
+
+cc_library(
+    name = "transitive_defines_from_bazel_target",
+    hdrs = ["transitive_defines_from_bazel_target.h"],
+    deps = [
+        "//test/aspect/defines/lib:a",
+        "//test/aspect/defines/support:transitive_define",
+    ],
+)

--- a/test/aspect/defines/README.md
+++ b/test/aspect/defines/README.md
@@ -1,0 +1,11 @@
+Defines can influence which include statements are relevant.
+
+These tests concentrate on parsing single files based on defines:
+
+- specified in the parsed file itself
+- coming from the C/C++ toolchain
+- defined by the Bazel target attributes `defines`, `local_defines` or `cops`
+
+Defines can also be imported into a file via an included header which specifies a define.
+This use case is not yet supported.
+We might add it at a later stage.

--- a/test/aspect/defines/defines_from_bazel_target.h
+++ b/test/aspect/defines/defines_from_bazel_target.h
@@ -1,0 +1,17 @@
+#ifdef SOME_DEFINE
+#include "test/aspect/defines/lib/a.h"
+#else
+#include "test/aspect/defines/lib/b.h"
+#endif
+
+#ifdef LOCAL_DEFINE
+#include "test/aspect/defines/lib/a.h"
+#else
+#include "test/aspect/defines/lib/b.h"
+#endif
+
+#if SOME_COPT > 40
+#include "test/aspect/defines/lib/a.h"
+#else
+#include "test/aspect/defines/lib/b.h"
+#endif

--- a/test/aspect/defines/in_file_defines.h
+++ b/test/aspect/defines/in_file_defines.h
@@ -1,0 +1,19 @@
+#define USE_A
+
+#ifdef USE_A
+#include "test/aspect/defines/lib/a.h"
+#else
+#include "test/aspect/defines/lib/b.h"
+#endif
+
+#ifdef NON_EXISTING_DEFINE
+#include "test/aspect/defines/lib/b.h"
+#endif
+
+#define SOME_VALUE 42
+
+#if SOME_VALUE > 40
+#include "test/aspect/defines/lib/a.h"
+#else
+#include "test/aspect/defines/lib/b.h"
+#endif

--- a/test/aspect/defines/lib/BUILD
+++ b/test/aspect/defines/lib/BUILD
@@ -1,0 +1,11 @@
+cc_library(
+    name = "a",
+    hdrs = ["a.h"],
+    visibility = ["//test/aspect/defines:__pkg__"],
+)
+
+cc_library(
+    name = "b",
+    hdrs = ["b.h"],
+    visibility = ["//test/aspect/defines:__pkg__"],
+)

--- a/test/aspect/defines/support/BUILD
+++ b/test/aspect/defines/support/BUILD
@@ -1,0 +1,7 @@
+cc_library(
+    name = "transitive_define",
+    copts = ["-DLOCAL_COPT"],  # should not influence other targets
+    defines = ["TRANSITIVE_DEFINE"],
+    local_defines = ["LOCAL_DEFINE"],  # should not influence other targets
+    visibility = ["//test/aspect/defines:__pkg__"],
+)

--- a/test/aspect/defines/transitive_defines_from_bazel_target.h
+++ b/test/aspect/defines/transitive_defines_from_bazel_target.h
@@ -1,0 +1,18 @@
+// Define introduced through target on which we depend. The target uses the attribute 'defines' which is propagated to
+// all users of the target.
+#ifdef TRANSITIVE_DEFINE
+#include "test/aspect/defines/lib/a.h"
+#else
+#include "test/aspect/defines/lib/b.h"
+#endif
+
+// The following defines shall never be active as they are set though Bazel target attributes 'copts' and
+// 'local_defines' which should not leak to users of the target
+
+#ifdef LOCAL_DEFINE
+#include "test/aspect/defines/lib/b.h"
+#endif
+
+#ifdef LOCAL_COPT
+#include "test/aspect/defines/lib/b.h"
+#endif

--- a/test/aspect/execute_tests.py
+++ b/test/aspect/execute_tests.py
@@ -296,6 +296,22 @@ TESTS = [
         ),
         expected=ExpectedResult(success=True),
     ),
+    TestCase(
+        name="defines_from_bazel_target",
+        cmd=TestCmd(
+            target="//test/aspect/defines:defines_from_bazel_target",
+            aspect=DEFAULT_ASPECT,
+        ),
+        expected=ExpectedResult(success=True),
+    ),
+    TestCase(
+        name="transitive_defines_from_bazel_target",
+        cmd=TestCmd(
+            target="//test/aspect/defines:transitive_defines_from_bazel_target",
+            aspect=DEFAULT_ASPECT,
+        ),
+        expected=ExpectedResult(success=True),
+    ),
 ]
 
 if __name__ == "__main__":

--- a/test/aspect/execute_tests.py
+++ b/test/aspect/execute_tests.py
@@ -288,6 +288,14 @@ TESTS = [
         ),
         expected=ExpectedResult(success=True),
     ),
+    TestCase(
+        name="in_file_defines",
+        cmd=TestCmd(
+            target="//test/aspect/defines:in_file_defines",
+            aspect=DEFAULT_ASPECT,
+        ),
+        expected=ExpectedResult(success=True),
+    ),
 ]
 
 if __name__ == "__main__":

--- a/test/aspect/recursion/README.md
+++ b/test/aspect/recursion/README.md
@@ -1,3 +1,3 @@
-The aspect can analyze either solely the targets is is being executed on or it can can analyze the whole dependency tree.
+The aspect can analyze either solely the targets is being executed on or it can analyze the whole dependency tree.
 
 One can use a rule to perform the aspect analysis as part of a normal build.


### PR DESCRIPTION
The preprocessor based on `pcpp`, which we introduced earlier, already allows processing defines in files and thus automatically skipping irrelevant include statements.
Now we utilize this preprocessor to enable processing defines which have been set through Bazel or internally in a file which is analyzed.