### PR TITLE
Update project to use Python 3.7 and 3.8 features

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,6 +48,6 @@ repos:
       - id: pyupgrade
         name: pyupgrade
         entry: poetry run pyupgrade
-        args: [ --py36-plus ]
+        args: [ --py38-plus ]
         language: system
         types: [ python ]

--- a/README.md
+++ b/README.md
@@ -228,10 +228,16 @@ the analysis changes.
 
 # Supported Platforms
 
+TODO 3.8
+
+- Assignment expressions
+- f-strings support = for self-documenting expressions and debugging
+- shlex useful?
+
 | Platform         | Constraints                                                                                      |
 | ---------------- | ------------------------------------------------------------------------------------------------ |
 | Operating system | No constraints. However, Ubuntu 20.04 is currently the only OS used for development and testing. |
-| Python           | Minimum version is 3.6. Tests are currently running based on Python 3.8.                         |
+| Python           | Minimum version is 3.8. Tests are currenntly only performed with 3.8.                            |
 | Bazel            | Minimum version is 4.0.0. Multiple versions are tested.                                          |
 | Buildozer        | No known limitations. Tests have been performed with 5.0.1.                                      |
 

--- a/docs/project_design_rationales.md
+++ b/docs/project_design_rationales.md
@@ -50,16 +50,10 @@ The aspect implementation is not compatible to old Bazel versions due to:
 - Before 4.0.0 the global `json` module is not available in Starlark
 - Bazel 4.0.0 is the first LTS version
 
-## Why is Python \< 3.6 not supported
+## Why is Python \< 3.8 not supported
 
-As a rule of thumb, we aim to only support Python versions which are not EOL. Using a modern Python version enables
-us to write clean code utilizing modern Python features.
-
-Nevertheless, we support Python 3.6, although it is already EOL. This version is the default for Ubuntu 18.04, which
-a lot of users are still using. Thus, we make an exception for Python 3.6.
-
-We are not making this exception for even older versions. Especially given we make extensive use of the features
-_formatting string literals_ and _type annotations_, which are at not available in older versions.
+We aim to only support Python versions which are not EOL.
+Using a modern Python version enables us to write lean code utilizing modern Python features.
 
 # Rejected Concepts
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,0 @@
-# File is required to make coverage computation working

--- a/src/analyze_includes/__init__.py
+++ b/src/analyze_includes/__init__.py
@@ -1,1 +1,0 @@
-# File is required to make coverage computation working

--- a/src/analyze_includes/evaluate_includes.py
+++ b/src/analyze_includes/evaluate_includes.py
@@ -1,7 +1,8 @@
 from collections import defaultdict
+from dataclasses import dataclass, field
 from json import dumps
 from pathlib import Path
-from typing import DefaultDict, List, Optional
+from typing import DefaultDict, List
 
 from src.analyze_includes.parse_source import Include
 from src.analyze_includes.system_under_inspection import (
@@ -11,24 +12,15 @@ from src.analyze_includes.system_under_inspection import (
 )
 
 
+@dataclass
 class Result:
-    def __init__(
-        self,
-        target: str,
-        public_includes_without_dep: Optional[List[Include]] = None,
-        private_includes_without_dep: Optional[List[Include]] = None,
-        unused_public_deps: Optional[List[str]] = None,
-        unused_private_deps: Optional[List[str]] = None,
-        deps_which_should_be_private: Optional[List[str]] = None,
-        use_implementation_deps=False,
-    ) -> None:
-        self.target = target
-        self.public_includes_without_dep = public_includes_without_dep if public_includes_without_dep else []
-        self.private_includes_without_dep = private_includes_without_dep if private_includes_without_dep else []
-        self.unused_public_deps = unused_public_deps if unused_public_deps else []
-        self.unused_private_deps = unused_private_deps if unused_private_deps else []
-        self.deps_which_should_be_private = deps_which_should_be_private if deps_which_should_be_private else []
-        self.use_implementation_deps = use_implementation_deps
+    target: str
+    public_includes_without_dep: List[Include] = field(default_factory=list)
+    private_includes_without_dep: List[Include] = field(default_factory=list)
+    unused_public_deps: List[str] = field(default_factory=list)
+    unused_private_deps: List[str] = field(default_factory=list)
+    deps_which_should_be_private: List[str] = field(default_factory=list)
+    use_implementation_deps: bool = False
 
     def is_ok(self) -> bool:
         return (

--- a/src/analyze_includes/parse_source.py
+++ b/src/analyze_includes/parse_source.py
@@ -1,4 +1,5 @@
 import re
+from dataclasses import dataclass
 from io import StringIO
 from pathlib import Path
 from typing import List, Union
@@ -26,12 +27,12 @@ class SimpleParsingPreprocessor(Preprocessor):
         pass
 
 
+@dataclass
 class Include:
     """Single include statement in a specific file"""
 
-    def __init__(self, file: Path, include: str) -> None:
-        self.file = file
-        self.include = include
+    file: Path
+    include: str
 
     def __eq__(self, other: object) -> bool:
         return self.file == other.file and self.include == other.include
@@ -46,15 +47,15 @@ class Include:
         return f"File='{self.file}', include='{self.include}'"
 
 
+@dataclass
 class IgnoredIncludes:
     """
     We ignore some include statements during analysis. For example header from the standard library, but also paths
     or headers chosen by the user.
     """
 
-    def __init__(self, paths: List[str], patterns: List[str]) -> None:
-        self.paths = paths
-        self.patterns = patterns
+    paths: List[str]
+    patterns: List[str]
 
     def is_ignored(self, include: str) -> bool:
         is_ignored_path = include in self.paths

--- a/src/analyze_includes/system_under_inspection.py
+++ b/src/analyze_includes/system_under_inspection.py
@@ -1,4 +1,5 @@
 import json
+from dataclasses import dataclass
 from enum import Enum, auto
 from pathlib import Path
 from typing import Dict, List
@@ -65,36 +66,30 @@ class IncludePath:
         return f"IncludePath(path='{self.path}', usage='{self.usage}')"
 
 
+@dataclass
 class CcTarget:
     """A cc_* rule target and the available information associated with it."""
 
-    def __init__(self, name: str, include_paths: List[IncludePath], header_files: List[HeaderFile]) -> None:
-        self.name = name
-        self.include_paths = include_paths
-        self.header_files = header_files
+    name: str
+    include_paths: List[IncludePath]
+    header_files: List[HeaderFile]
 
     def __repr__(self) -> str:
         return f"CcTarget(name='{self.name}', include_paths={self.include_paths}, header_files={self.header_files})"
 
 
+@dataclass
 class SystemUnderInspection:
     """A target whose include statements are analyzed and its dependencies."""
 
-    def __init__(
-        self,
-        public_deps: List[CcTarget],
-        private_deps: List[CcTarget],
-        defines: List[str],
-        target_under_inspection: CcTarget,
-    ) -> None:
-        # Dependencies which are available to downstream dependencies of the target under inspection
-        self.public_deps = public_deps
-        # Dependencies which are NOT available to downstream dependencies of the target under inspection
-        self.private_deps = private_deps
-        # Defines influencing the preprocessor
-        self.defines = defines
-        # Target under inspection
-        self.target_under_inspection = target_under_inspection
+    # Dependencies which are available to downstream dependencies of the target under inspection
+    public_deps: List[CcTarget]
+    # Dependencies which are NOT available to downstream dependencies of the target under inspection
+    private_deps: List[CcTarget]
+    # Defines influencing the preprocessor
+    defines: List[str]
+    # Target under inspection
+    target_under_inspection: CcTarget
 
 
 def _make_cc_target(info: Dict) -> CcTarget:

--- a/src/analyze_includes/test/__init__.py
+++ b/src/analyze_includes/test/__init__.py
@@ -1,1 +1,0 @@
-# File is required to make coverage computation working

--- a/src/analyze_includes/test/evaluate_includes_test.py
+++ b/src/analyze_includes/test/evaluate_includes_test.py
@@ -259,13 +259,13 @@ class TestResult(unittest.TestCase):
 
 
 def test_set_use_implementation_deps(self):
-    unit = Result(use_implementation_deps=True)
+    unit = Result(target="//:foo", use_implementation_deps=True)
 
     self.assertEqual(
         unit.to_json(),
         """
 {
-"analyzed_target": "",
+"analyzed_target": "//:foo",
 "public_includes_without_dep": {},
 "private_includes_without_dep": {},
 "unused_public_deps": [],

--- a/src/analyze_includes/test/parse_config_test.py
+++ b/src/analyze_includes/test/parse_config_test.py
@@ -7,41 +7,41 @@ from src.analyze_includes.std_header import STD_HEADER
 
 class TestGetIgnoredIncludes(unittest.TestCase):
     def test_no_config_file_provided(self):
-        ignored_inclues = get_ignored_includes(None)
+        ignored_includes = get_ignored_includes(None)
 
-        self.assertEqual(ignored_inclues.paths, list(STD_HEADER))
-        self.assertEqual(ignored_inclues.patterns, [])
+        self.assertEqual(ignored_includes.paths, list(STD_HEADER))
+        self.assertEqual(ignored_includes.patterns, [])
 
     def test_empty_config_file(self):
-        ignored_inclues = get_ignored_includes(Path("src/analyze_includes/test/data/config/empty.json"))
+        ignored_includes = get_ignored_includes(Path("src/analyze_includes/test/data/config/empty.json"))
 
-        self.assertEqual(ignored_inclues.paths, list(STD_HEADER))
-        self.assertEqual(ignored_inclues.patterns, [])
+        self.assertEqual(ignored_includes.paths, list(STD_HEADER))
+        self.assertEqual(ignored_includes.patterns, [])
 
     def test_extra_ignore_paths(self):
-        ignored_inclues = get_ignored_includes(Path("src/analyze_includes/test/data/config/extra_ignore_paths.json"))
+        ignored_includes = get_ignored_includes(Path("src/analyze_includes/test/data/config/extra_ignore_paths.json"))
 
-        self.assertEqual(len(ignored_inclues.paths), len(list(STD_HEADER)) + 2)
-        self.assertTrue("foo" in ignored_inclues.paths)
-        self.assertTrue("bar" in ignored_inclues.paths)
-        self.assertEqual(ignored_inclues.patterns, [])
+        self.assertEqual(len(ignored_includes.paths), len(list(STD_HEADER)) + 2)
+        self.assertTrue("foo" in ignored_includes.paths)
+        self.assertTrue("bar" in ignored_includes.paths)
+        self.assertEqual(ignored_includes.patterns, [])
 
     def test_override_default_ignore_patterns(self):
-        ignored_inclues = get_ignored_includes(
+        ignored_includes = get_ignored_includes(
             Path("src/analyze_includes/test/data/config/overwrite_default_ignore_paths.json")
         )
 
-        self.assertEqual(len(ignored_inclues.paths), 3)
-        self.assertTrue("foo" in ignored_inclues.paths)
-        self.assertTrue("bar" in ignored_inclues.paths)
-        self.assertTrue("foobar" in ignored_inclues.paths)
-        self.assertEqual(ignored_inclues.patterns, [])
+        self.assertEqual(len(ignored_includes.paths), 3)
+        self.assertTrue("foo" in ignored_includes.paths)
+        self.assertTrue("bar" in ignored_includes.paths)
+        self.assertTrue("foobar" in ignored_includes.paths)
+        self.assertEqual(ignored_includes.patterns, [])
 
     def test_ignore_patterns(self):
-        ignored_inclues = get_ignored_includes(Path("src/analyze_includes/test/data/config/ignore_patterns.json"))
+        ignored_includes = get_ignored_includes(Path("src/analyze_includes/test/data/config/ignore_patterns.json"))
 
-        self.assertEqual(ignored_inclues.paths, list(STD_HEADER))
-        self.assertEqual(ignored_inclues.patterns, ["foo", "bar"])
+        self.assertEqual(ignored_includes.paths, list(STD_HEADER))
+        self.assertEqual(ignored_includes.patterns, ["foo", "bar"])
 
 
 if __name__ == "__main__":

--- a/src/apply_fixes/buildozer_executor.py
+++ b/src/apply_fixes/buildozer_executor.py
@@ -29,9 +29,7 @@ class BuildozerExecutor:
     def execute(self, task: str, target: str) -> None:
         command = self._base_cmd + [task, target]
         logging.log(logging.INFO if self._dry else logging.DEBUG, f"Executing buildozer command: {command}")
-        process = subprocess.run(
-            command, cwd=self._workspace, check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE
-        )
+        process = subprocess.run(command, cwd=self._workspace, check=False, capture_output=True)
         self._summary.add_command(cmd=command, buildozer_result=process.returncode)
 
     @staticmethod

--- a/src/apply_fixes/summary.py
+++ b/src/apply_fixes/summary.py
@@ -1,15 +1,16 @@
+from dataclasses import dataclass, field
 from typing import List
 
 
+@dataclass
 class Summary:
-    def __init__(self) -> None:
-        self.succesful_fixes = []
-        self.failed_fixes = []
-        self.fixes_without_effect = []
+    successful_fixes: List[List[str]] = field(default_factory=list)
+    failed_fixes: List[List[str]] = field(default_factory=list)
+    fixes_without_effect: List[List[str]] = field(default_factory=list)
 
     def add_command(self, cmd: List[str], buildozer_result: int) -> None:
         if buildozer_result == 0:
-            self.succesful_fixes.append(cmd)
+            self.successful_fixes.append(cmd)
         elif buildozer_result == 2:
             self.failed_fixes.append(cmd)
         elif buildozer_result == 3:
@@ -20,7 +21,7 @@ class Summary:
             )
 
     def print_summary(self) -> None:
-        print(f"\nSuccesful fixes: {len(self.succesful_fixes)}")
+        print(f"\nSuccessful fixes: {len(self.successful_fixes)}")
 
         if self.failed_fixes:
             print(

--- a/src/apply_fixes/test/summary_test.py
+++ b/src/apply_fixes/test/summary_test.py
@@ -7,7 +7,7 @@ class TestSummary(unittest.TestCase):
     def test_add_succeeding_command(self):
         unit = Summary()
         unit.add_command(cmd=["foo", "bar"], buildozer_result=0)
-        self.assertEqual(unit.succesful_fixes, [["foo", "bar"]])
+        self.assertEqual(unit.successful_fixes, [["foo", "bar"]])
 
     def test_add_command_without_effect(self):
         unit = Summary()

--- a/test/apply_fixes/execute_tests.py
+++ b/test/apply_fixes/execute_tests.py
@@ -18,8 +18,7 @@ def cli():
         nargs="+",
         help="Run the specified test cases. Substrings will match against all test names including them.",
     )
-    args = parser.parse_args()
-    return args
+    return parser.parse_args()
 
 
 if __name__ == "__main__":

--- a/test/apply_fixes/test_case.py
+++ b/test/apply_fixes/test_case.py
@@ -96,13 +96,11 @@ class TestCaseBase(ABC):
         if logging.getLogger().isEnabledFor(logging.DEBUG):
             subprocess.run(cmd, cwd=self._workspace, **kwargs)
         else:
-            subprocess.run(cmd, cwd=self._workspace, stdout=subprocess.PIPE, stderr=subprocess.PIPE, **kwargs)
+            subprocess.run(cmd, cwd=self._workspace, capture_output=True, **kwargs)
 
     def _run_and_capture_cmd(self, cmd: List[str], **kwargs) -> subprocess.CompletedProcess:
         logging.debug(f"Executing command: {cmd}")
-        process = subprocess.run(
-            cmd, cwd=self._workspace, encoding="utf-8", stdout=subprocess.PIPE, stderr=subprocess.PIPE, **kwargs
-        )
+        process = subprocess.run(cmd, cwd=self._workspace, capture_output=True, text=True, **kwargs)
         logging.debug(process.stdout)
         logging.debug(process.stderr)
         return process


### PR DESCRIPTION
This increases the minimum Python version required to use this project to 3.8.

Changes motivated by new Python version:
- Use modern `subprocess.run` API
- Use `dataclass`

Generic Python refactoring:
- More specific typing, no longer use `Any`
- Remove superfluous `__init__.py` files
- Fix typos
- Inline some expressions


Resolves: https://github.com/martis42/depend_on_what_you_use/issues/117