### PR TITLE
Use `no-dwyu` tag to allow skipping checks on specific targets.

### DIFF
--- a/src/aspect/dwyu.bzl
+++ b/src/aspect/dwyu.bzl
@@ -224,6 +224,10 @@ def dwyu_aspect_impl(target, ctx):
     if not CcInfo in target:
         return []
 
+    # Skip targets which explicitly opt-out
+    if "no-dwyu" in ctx.rule.attr.tags:
+        return []
+
     public_files, private_files = _parse_sources(ctx.rule.attr)
     if not public_files and not private_files:
         return []

--- a/test/aspect/execute_tests.py
+++ b/test/aspect/execute_tests.py
@@ -88,6 +88,11 @@ TESTS = [
         expected=ExpectedResult(success=False, unused_public_deps=["//test/aspect/unused_dep:foo"]),
     ),
     TestCase(
+        name="unused_dep_skipped",
+        cmd=TestCmd(target="//test/aspect/unused_dep:main_skipped", aspect=DEFAULT_ASPECT),
+        expected=ExpectedResult(success=True),
+    ),
+    TestCase(
         name="unused_private_dep",
         cmd=TestCmd(
             target="//test/aspect/unused_dep/implementation_deps:implementation_deps_lib",

--- a/test/aspect/execute_tests_impl.py
+++ b/test/aspect/execute_tests_impl.py
@@ -2,6 +2,7 @@ import os
 import subprocess as sb
 from argparse import ArgumentParser, Namespace
 from dataclasses import dataclass, field
+from shutil import which
 from typing import Dict, List, Union
 
 # Each line in the output corresponding to an error is expected to start with this
@@ -157,7 +158,8 @@ def verify_test(test: TestCase, process: sb.CompletedProcess, verbose: bool) -> 
 
 
 def make_cmd(test_cmd: TestCmd, extra_args: List[str]) -> List[str]:
-    cmd = ["bazelisk", "build", "--noshow_progress"]
+    bazel = which("bazelisk") or which("bazel")
+    cmd = [bazel, "build", "--noshow_progress"]
     if test_cmd.aspect:
         cmd.extend([f"--aspects={test_cmd.aspect}", "--output_groups=cc_dwyu_output"])
     cmd.extend(extra_args)

--- a/test/aspect/execute_tests_utest.py
+++ b/test/aspect/execute_tests_utest.py
@@ -1,4 +1,5 @@
 import unittest
+from shutil import which
 
 from execute_tests_impl import (
     CATEGORY_INVALID_INCLUDES,
@@ -166,7 +167,8 @@ class TestExpectedResult(unittest.TestCase):
 class TestMakeCmd(unittest.TestCase):
     @staticmethod
     def _base_cmd():
-        return ["bazelisk", "build", "--noshow_progress"]
+        bazel = which("bazelisk") or which("bazel")
+        return [bazel, "build", "--noshow_progress"]
 
     def test_basic_cmd(self):
         cmd = make_cmd(test_cmd=TestCmd(target="//foo:bar"), extra_args=[])

--- a/test/aspect/unused_dep/BUILD
+++ b/test/aspect/unused_dep/BUILD
@@ -25,3 +25,14 @@ cc_binary(
         ":foo",
     ],
 )
+
+# SUCCESS: This rule is skipped due to the tag `no-dwyu`.
+cc_binary(
+    name = "main_skipped",
+    srcs = [":using_bar"],
+    tags = ["no-dwyu"],
+    deps = [
+        ":bar",
+        ":foo",
+    ],
+)


### PR DESCRIPTION
Prototype for #123.