### PR TITLE
Optimize aspect integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,6 +38,8 @@ jobs:
         run: bazel test //src/... //test/aspect:all
       - name: Execute Mypy
         run: bazel build --config=mypy //src/... //test/aspect:all
+      - name: Integration Tests
+        run: ./test/aspect/execute_tests.py
 
   # tests:
   #   runs-on: ubuntu-20.04


### PR DESCRIPTION
Resetting bazel-out to use another Bazel version takes almost as long as executing the integration tests. Thus, we use a dedicated output directory for each Bazel version. This significantly speeds up consecutively executing the integration tests multiple times.