### PR TITLE
Use multiple Python versions for aspect integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,12 +242,12 @@ TODO 3.8
 - f-strings support = for self-documenting expressions and debugging
 - shlex useful?
 
-| Platform         | Constraints                                                                                      |
-| ---------------- | ------------------------------------------------------------------------------------------------ |
-| Operating system | No constraints. However, Ubuntu 20.04 is currently the only OS used for development and testing. |
-| Python           | Minimum version is 3.8. Tests are currently only performed with 3.8.                             |
-| Bazel            | Minimum version is 5.0.0. Multiple versions are tested.                                          |
-| Buildozer        | No known limitations. Tests have been performed with 5.0.1.                                      |
+| Platform         | Constraints                                                                                                |
+| ---------------- | ---------------------------------------------------------------------------------------------------------- |
+| Operating system | No constraints by design. However, Ubuntu 20.04 is currently the only OS used for development and testing. |
+| Python           | Minimum version is 3.8. Multiple versions are tested.                                                      |
+| Bazel            | Minimum version is 5.0.0. Multiple versions are tested.                                                    |
+| Buildozer        | No known limitations. Tests have been performed with 5.0.1.                                                |
 
 # Alternatives to DWYU
 

--- a/dev_setup_step_2.bzl
+++ b/dev_setup_step_2.bzl
@@ -1,6 +1,7 @@
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 load("@mypy_integration//repositories:deps.bzl", mypy_deps = "deps")
 load("@mypy_integration//repositories:repositories.bzl", mypy_integration_dependencies = "repositories")
+load("@rules_python//python:repositories.bzl", "python_register_multi_toolchains")
 
 def dev_setup_step_2():
     """
@@ -9,3 +10,14 @@ def dev_setup_step_2():
     bazel_skylib_workspace()
     mypy_deps("//third_party:mypy_requirements.txt")
     mypy_integration_dependencies()
+
+    # Choose different version via: --@rules_python//python/config_settings:python_version=X
+    python_register_multi_toolchains(
+        name = "python",
+        default_version = "3.10.9",
+        python_versions = [
+            "3.8.15",
+            "3.9.16",
+            "3.11.1",
+        ],
+    )

--- a/setup_step_2.bzl
+++ b/setup_step_2.bzl
@@ -5,6 +5,12 @@ def setup_step_2():
     """
     Perform the second setup step.
     """
+
+    # Strictly speaking we should use one pip_parse per Python version. However, pcpp has no transitive dependencies
+    # and only a single wheel for all Python versions. Thus, we simply use a single resolved requirements file for all
+    # Python versions.
+    # Furthermore, this code is executed by the users of DWYU and we don't want to impose a specific Python interpreter
+    # onto them.
     pip_parse(
         name = "dwyu_py_deps",
         requirements_lock = "@depend_on_what_you_use//third_party:requirements.txt",

--- a/test/aspect/execute_tests.py
+++ b/test/aspect/execute_tests.py
@@ -6,16 +6,19 @@ from execute_tests_impl import (
     ExpectedResult,
     TestCase,
     TestCmd,
+    TestedVersions,
     cli,
     main,
 )
 
-BAZEL_VERSIONS = [
-    "5.0.0",
-    "5.4.1",
-    "6.0.0",
-    "6.2.0",
-    "7.0.0-pre.20230502.1",
+# Test matrix. We don't combine each Bazel version with each Python version as there is no significant benefit. We
+# manually define pairs which make sure each Bazel and Python version we care about is used at least once.
+TESTED_VERSIONS = [
+    TestedVersions(bazel="5.0.0", python="3.8.15"),
+    TestedVersions(bazel="5.4.1", python="3.9.16"),
+    TestedVersions(bazel="6.0.0", python="3.10.9"),
+    TestedVersions(bazel="6.2.0", python="3.11.1"),
+    TestedVersions(bazel="7.0.0-pre.20230502.1", python="3.11.1"),
 ]
 
 # When Bazel 7.0.0 releases we have to look again at the flags and check if more flags are available
@@ -289,6 +292,8 @@ TESTS = [
 
 if __name__ == "__main__":
     args = cli()
+    if not args:
+        sys.exit(1)
     sys.exit(
-        main(args=args, test_cases=TESTS, test_versions=BAZEL_VERSIONS, version_specific_args=VERSION_SPECIFIC_ARGS)
+        main(args=args, test_cases=TESTS, tested_versions=TESTED_VERSIONS, version_specific_args=VERSION_SPECIFIC_ARGS)
     )

--- a/test/aspect/execute_tests_impl.py
+++ b/test/aspect/execute_tests_impl.py
@@ -231,7 +231,7 @@ def execute_tests(
     return failed_tests
 
 
-def cli():
+def cli() -> Optional[Namespace]:
     parser = ArgumentParser()
     parser.add_argument("--verbose", "-v", action="store_true", help="Show output of test runs.")
     parser.add_argument(
@@ -262,7 +262,7 @@ def main(
     test_cases: List[TestCase],
     tested_versions: List[TestedVersions],
     version_specific_args: Dict[str, CompatibleVersions],
-):
+) -> int:
     if args.bazel and args.python:
         versions = [TestedVersions(bazel=args.bazel, python=args.python)]
     else:


### PR DESCRIPTION
We add hermetic Python toolchains for development. This allows reproducible behavior across multiple developer machines.
Furthermore, this allows us to easily test multiple Python versions. This is important since a significant part of DWYU is implemented in Python.

Related to https://github.com/martis42/depend_on_what_you_use/issues/8
Fixes https://github.com/martis42/depend_on_what_you_use/issues/42