### PR TITLE
Rework include path analysis

### DIFF
--- a/src/analyze_includes/test/data/dep_info_bar.json
+++ b/src/analyze_includes/test/data/dep_info_bar.json
@@ -1,8 +1,4 @@
 {
-  "include_paths": [
-    "public/dep/bar_a.h",
-    "public/dep/bar_b.h"
-  ],
   "header_files": [
     "public/dep/bar_1.h",
     "public/dep/bar_2.h"

--- a/src/analyze_includes/test/data/dep_info_foo.json
+++ b/src/analyze_includes/test/data/dep_info_foo.json
@@ -1,8 +1,4 @@
 {
-  "include_paths": [
-    "public/dep/foo_a.h",
-    "public/dep/foo_b.h"
-  ],
   "header_files": [
     "public/dep/foo_1.h",
     "public/dep/foo_2.h"

--- a/src/analyze_includes/test/data/implementation_dep_info_bar.json
+++ b/src/analyze_includes/test/data/implementation_dep_info_bar.json
@@ -1,8 +1,4 @@
 {
-  "include_paths": [
-    "private/dep/bar_a.h",
-    "private/dep/bar_b.h"
-  ],
   "header_files": [
     "private/dep/bar_1.h",
     "private/dep/bar_2.h"

--- a/src/analyze_includes/test/data/implementation_dep_info_foo.json
+++ b/src/analyze_includes/test/data/implementation_dep_info_foo.json
@@ -1,8 +1,4 @@
 {
-  "include_paths": [
-    "private/dep/foo_a.h",
-    "private/dep/foo_b.h"
-  ],
   "header_files": [
     "private/dep/foo_1.h",
     "private/dep/foo_2.h"

--- a/src/analyze_includes/test/data/target_under_inspection.json
+++ b/src/analyze_includes/test/data/target_under_inspection.json
@@ -3,10 +3,9 @@
     "SOME_DEFINE",
     "ANOTHER_DEFINE=42"
   ],
-  "include_paths": [
-    "self/a.h",
-    "self/b.h"
-  ],
+  "includes": ["."],
+  "quote_includes": ["some/dir"],
+  "system_includes": ["another/dir"],
   "header_files": [
     "self/header_1.h",
     "self/header_2.h"

--- a/src/analyze_includes/test/data/target_under_inspection_empty.json
+++ b/src/analyze_includes/test/data/target_under_inspection_empty.json
@@ -1,6 +1,8 @@
 {
   "defines": [],
-  "include_paths": [],
+  "includes": [],
+  "quote_includes": [],
+  "system_includes": [],
   "header_files": [],
   "target": "//:foo"
 }

--- a/src/analyze_includes/test/system_under_inspection_test.py
+++ b/src/analyze_includes/test/system_under_inspection_test.py
@@ -1,11 +1,8 @@
 import unittest
 from pathlib import Path
-from typing import List
 
 from src.analyze_includes.system_under_inspection import (
     CcTarget,
-    HeaderFile,
-    IncludePath,
     UsageStatus,
     UsageStatusTracker,
     get_system_under_inspection,
@@ -74,48 +71,14 @@ class TestUsageStatusTracker(unittest.TestCase):
         self.assertEqual(repr(unit_d), "PUBLIC_AND_PRIVATE")
 
 
-class TestHeaderFile(unittest.TestCase):
-    def test_repr(self):
-        unit = HeaderFile("foo/bar.h")
-
-        self.assertEqual(repr(unit), "HeaderFile(path='foo/bar.h', usage='NONE')")
-
-
-class TestIncludePath(unittest.TestCase):
-    def test_repr(self):
-        unit = IncludePath("foo/bar.h")
-
-        self.assertEqual(repr(unit), "IncludePath(path='foo/bar.h', usage='NONE')")
-
-
 class TestCcTarget(unittest.TestCase):
     def test_repr(self):
-        unit = CcTarget(name="//:foo", include_paths=[IncludePath("foo.h")], header_files=[HeaderFile("bar.h")])
+        unit = CcTarget(name="//:foo", header_files=["bar.h"])
 
-        self.assertEqual(
-            repr(unit),
-            "CcTarget(name='//:foo',"
-            " include_paths=[IncludePath(path='foo.h', usage='NONE')],"
-            " header_files=[HeaderFile(path='bar.h', usage='NONE')])",
-        )
+        self.assertEqual(repr(unit), "CcTarget(name='//:foo', usage='NONE', header_files=['bar.h'])")
 
 
 class TestGetSystemUnderInspection(unittest.TestCase):
-    def check_target(
-        self, actual: CcTarget, expected_name: str, expected_paths: List[str], expected_files: List[str]
-    ) -> None:
-        self.assertEqual(actual.name, expected_name)
-
-        self.assertEqual(len(actual.include_paths), len(expected_paths))
-        for ip, expected_path in zip(actual.include_paths, expected_paths):
-            self.assertEqual(ip.path, expected_path)
-            self.assertEqual(ip.usage.usage, UsageStatus.NONE)
-
-        self.assertEqual(len(actual.header_files), len(expected_files))
-        for hf, expected_file in zip(actual.header_files, expected_files):
-            self.assertEqual(hf.path, expected_file)
-            self.assertEqual(hf.usage.usage, UsageStatus.NONE)
-
     def test_load_full_file(self):
         sui = get_system_under_inspection(
             target_under_inspection=Path("src/analyze_includes/test/data/target_under_inspection.json"),
@@ -129,42 +92,28 @@ class TestGetSystemUnderInspection(unittest.TestCase):
             ],
         )
 
-        self.assertEqual(len(sui.implementation_deps), 2)
-        self.check_target(
-            actual=sui.implementation_deps[0],
-            expected_name="//private/dep:foo",
-            expected_paths=["private/dep/foo_a.h", "private/dep/foo_b.h"],
-            expected_files=["private/dep/foo_1.h", "private/dep/foo_2.h"],
-        )
-        self.check_target(
-            actual=sui.implementation_deps[1],
-            expected_name="//private/dep:bar",
-            expected_paths=["private/dep/bar_a.h", "private/dep/bar_b.h"],
-            expected_files=["private/dep/bar_1.h", "private/dep/bar_2.h"],
-        )
+        self.assertEqual(sui.target_under_inspection.name, "//:baz")
+        self.assertEqual(sui.target_under_inspection.header_files, ["self/header_1.h", "self/header_2.h"])
+        self.assertEqual(sui.target_under_inspection.usage.usage, UsageStatus.NONE)
 
         self.assertEqual(len(sui.deps), 2)
-        self.check_target(
-            actual=sui.deps[0],
-            expected_name="//public/dep:foo",
-            expected_paths=["public/dep/foo_a.h", "public/dep/foo_b.h"],
-            expected_files=["public/dep/foo_1.h", "public/dep/foo_2.h"],
-        )
-        self.check_target(
-            actual=sui.deps[1],
-            expected_name="//public/dep:bar",
-            expected_paths=["public/dep/bar_a.h", "public/dep/bar_b.h"],
-            expected_files=["public/dep/bar_1.h", "public/dep/bar_2.h"],
-        )
+        self.assertEqual(sui.deps[0].name, "//public/dep:foo")
+        self.assertEqual(sui.deps[0].header_files, ["public/dep/foo_1.h", "public/dep/foo_2.h"])
+        self.assertEqual(sui.deps[0].usage.usage, UsageStatus.NONE)
+        self.assertEqual(sui.deps[1].name, "//public/dep:bar")
+        self.assertEqual(sui.deps[1].header_files, ["public/dep/bar_1.h", "public/dep/bar_2.h"])
+        self.assertEqual(sui.deps[1].usage.usage, UsageStatus.NONE)
 
+        self.assertEqual(len(sui.implementation_deps), 2)
+        self.assertEqual(sui.implementation_deps[0].name, "//private/dep:foo")
+        self.assertEqual(sui.implementation_deps[0].header_files, ["private/dep/foo_1.h", "private/dep/foo_2.h"])
+        self.assertEqual(sui.implementation_deps[0].usage.usage, UsageStatus.NONE)
+        self.assertEqual(sui.implementation_deps[1].name, "//private/dep:bar")
+        self.assertEqual(sui.implementation_deps[1].header_files, ["private/dep/bar_1.h", "private/dep/bar_2.h"])
+        self.assertEqual(sui.implementation_deps[1].usage.usage, UsageStatus.NONE)
+
+        self.assertEqual(sui.include_paths, ["", "some/dir", "another/dir"])
         self.assertEqual(sui.defines, ["SOME_DEFINE", "ANOTHER_DEFINE=42"])
-
-        self.check_target(
-            actual=sui.target_under_inspection,
-            expected_name="//:baz",
-            expected_paths=["self/a.h", "self/b.h"],
-            expected_files=["self/header_1.h", "self/header_2.h"],
-        )
 
     def test_load_empty_file(self):
         sui = get_system_under_inspection(
@@ -173,15 +122,13 @@ class TestGetSystemUnderInspection(unittest.TestCase):
             implementation_deps=[],
         )
 
-        self.assertEqual(len(sui.deps), 0)
-        self.assertEqual(len(sui.implementation_deps), 0)
-
-        self.check_target(
-            actual=sui.target_under_inspection,
-            expected_name="//:foo",
-            expected_paths=[],
-            expected_files=[],
-        )
+        self.assertEqual(sui.target_under_inspection.name, "//:foo")
+        self.assertEqual(sui.target_under_inspection.header_files, [])
+        self.assertEqual(sui.target_under_inspection.usage.usage, UsageStatus.NONE)
+        self.assertEqual(sui.deps, [])
+        self.assertEqual(sui.implementation_deps, [])
+        self.assertEqual(sui.include_paths, [])
+        self.assertEqual(sui.defines, [])
 
 
 if __name__ == "__main__":

--- a/src/aspect/dwyu.bzl
+++ b/src/aspect/dwyu.bzl
@@ -35,9 +35,11 @@ def _process_target(ctx, target, defines, output_path, is_target_under_inspectio
     args.add("--target", str(target.label))
     args.add("--output", processing_output)
     args.add_all("--header_files", header_files, expand_directories = True, omit_if_empty = False)
-    args.add_all("--system_includes", cc_context.system_includes, omit_if_empty = False)
-    args.add("--bin_dir", ctx.bin_dir.path)
-    args.add_all("--defines", defines)
+    if is_target_under_inspection:
+        args.add_all("--includes", cc_context.includes, omit_if_empty = False)
+        args.add_all("--quote_includes", cc_context.quote_includes, omit_if_empty = False)
+        args.add_all("--system_includes", cc_context.system_includes, omit_if_empty = False)
+        args.add_all("--defines", defines)
     if verbose:
         args.add("--verbose")
 

--- a/src/aspect/process_target.py
+++ b/src/aspect/process_target.py
@@ -14,17 +14,28 @@ def cli() -> Namespace:
     parser.add_argument("--output", required=True, type=Path, help="Stores the analysis in this file.")
     parser.add_argument("--header_files", required=True, nargs="*", help="Header files associated with the target.")
     parser.add_argument(
-        "--system_includes",
-        required=True,
+        "--includes",
         nargs="*",
-        help="System include directories defined by the target under inspection",
+        help="Include paths available to the compiler."
+        " Only relevant when analyzing the target under inspection itself. This is irrelevant for dependencies.",
     )
-    parser.add_argument("--bin_dir", required=True, type=str, help="Bazel bin output directory.")
+    parser.add_argument(
+        "--quote_includes",
+        nargs="*",
+        help="Include paths available to the compiler for quoted include statements."
+        " Only relevant when analyzing the target under inspection itself. This is irrelevant for dependencies.",
+    )
+    parser.add_argument(
+        "--system_includes",
+        nargs="*",
+        help="Include paths available to the compiler for system include statements"
+        " Only relevant when analyzing the target under inspection itself. This is irrelevant for dependencies.",
+    )
     parser.add_argument(
         "--defines",
         nargs="*",
         help="Defines for this target."
-        " Only relevant when analyzing the target under inspection itself. This is irrelevant for its dependencies.",
+        " Only relevant when analyzing the target under inspection itself. This is irrelevant for dependencies.",
     )
     parser.add_argument("--verbose", action="store_true", help="Print debugging output")
 
@@ -35,80 +46,21 @@ def cli() -> Namespace:
     return args
 
 
-def include_paths_from_file(file: str, system_includes: List[str], bin_dir: str, is_external: bool) -> List[str]:
-    if "_virtual_includes" in file:
-        # Header files available through a virtual include directories are given via the pattern:
-        # <pkg_dir_in_bazel_out>/_virtual_includes/<target_name>/<include_path_available_to_user>
-        return [file.split("_virtual_includes/", 1)[1].split("/", 1)[1]]
-
-    includes_from_system_paths = []
-    if system_includes:
-        for si in system_includes:
-            si_path = si + "/"
-            if file.startswith(si_path):
-                includes_from_system_paths.append(file.split(si_path, 1)[1])
-
-    # TODO investigate why returning early. Using absolute path relative to workspace root should always be possible
-    if includes_from_system_paths:
-        return includes_from_system_paths
-
-    if is_external:
-        # TODO is relying on 'external' working given the flags not using 'external' in runfiles trees?
-        # Header files available through a virtual include directories are given via the pattern:
-        # external/<external_workspace_name>/<include_path_available_to_user>
-        return [file.split("external/", 1)[1].split("/", 1)[1]]
-
-    # Generated code
-    if file.startswith(bin_dir):
-        return [file.split(f"{bin_dir}/", 1)[1]]
-
-    # Default case for dependencies from within the own workspace not using any include path manipulation
-    return [file]
-
-
-def get_include_paths(files: List[str], system_includes: List[str], bin_dir: str, is_external: bool) -> List[str]:
-    include_paths = []
-    for file in files:
-        include_paths.extend(
-            include_paths_from_file(
-                file=file, system_includes=system_includes, bin_dir=bin_dir, is_external=is_external
-            )
-        )
-    return include_paths
-
-
-def filter_files(files: List[str], is_external: bool) -> List[str]:
-    # TODO move this logic into the analyzer, as here it is a surprising impl detail
-    # The file list is used to resolve relative includes, which we don't do for external dependencies
-    if is_external:
-        return []
-    return files
-
-
-def is_external(target: str) -> bool:
-    """
-    Targets from external workspaces follow the pattern '@<workspace_name>//..' whereas targets from the own workspace
-    start with '@//...' or the short form '//...'.
-    """
-    return not target.startswith(("@//", "//"))
-
-
 def main(args: Namespace) -> int:
     logging.debug(f"\nAnalyzing dependency '{args.target}'")
     logging.debug(f"Output               '{args.output}'")
     logging.debug(f"Header files         '{args.header_files}'")
+    logging.debug(f"Includes             '{args.includes}'")
+    logging.debug(f"Quote includes       '{args.quote_includes}'")
     logging.debug(f"System includes      '{args.system_includes}'")
-    logging.debug(f"Bazel bin dir        '{args.bin_dir}'")
 
-    output = {"target": args.target}
-    is_external_target = is_external(args.target)
-    output["header_files"] = filter_files(files=args.header_files, is_external=is_external_target)
-    output["include_paths"] = get_include_paths(
-        files=args.header_files,
-        system_includes=args.system_includes,
-        bin_dir=args.bin_dir,
-        is_external=is_external_target,
-    )
+    output = {"target": args.target, "header_files": args.header_files}
+    if args.includes is not None:
+        output["includes"] = args.includes
+    if args.quote_includes is not None:
+        output["quote_includes"] = args.quote_includes
+    if args.system_includes is not None:
+        output["system_includes"] = args.system_includes
     if args.defines is not None:
         output["defines"] = args.defines
 


### PR DESCRIPTION
The old approach was based on the first experiments regarding DWYU. We did infer the paths at which headers can be included instead of relying on the information from the CcInfoo compilation_context. This has several drawbacks:
- The code is needlessly complex. There is no reason why we should require a custom logic. In contrast, we have to take care about special cases like external workspaces, which Bazel already handles.
- We introduce various assumptions which we did not motivate properly nor test properly
- Not having the include paths available in the analysis as they are available to the compiler is a limiting factor for using the preprocessor to parse defines