### PR TITLE
Support relative include statements for virtual paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,12 +169,11 @@ Examples for this can be seen at the [implementation_deps test cases](test/aspec
 
 ## Known limitations
 
-- If includes are added through a macro, this is invisible to DWYU.
+- Includes which are added through a preprocessor token are not recognized.
 - Fundamental support for processing preprocessor defines is present.
   However, if header _A_ specifies a define _X_ and is included in header _B_, header _B_ is not aware of _X_ from header _A_.
   Right now only defines specified through Bazel (e.g. toolchain or `cc_*` target attributes) or defines specified inside a file itself are used to process a file and discover include statements.
   We aim to resolve this limitation in a future release.
-- Include statements utilizing `..` are not recognized if they are used on virtual or system include paths.
 
 ## Applying automatic fixes
 

--- a/src/analyze_includes/test/evaluate_includes_test.py
+++ b/src/analyze_includes/test/evaluate_includes_test.py
@@ -355,16 +355,31 @@ class TestEvaluateIncludes(unittest.TestCase):
                 Include(file=Path("file1"), include="foo.h"),
                 Include(file=Path("file2"), include="dir/bar.h"),
             ],
-            private_includes=[
-                Include(file=Path("file4"), include="path/baz.h"),
-            ],
+            private_includes=[Include(file=Path("file4"), include="path/baz.h")],
             system_under_inspection=SystemUnderInspection(
                 target_under_inspection=CcTarget(name="foo", header_files=["self/own_header.h"]),
-                deps=[
-                    CcTarget(name="foo_pkg", header_files=["foo.h", "some/virtual/dir/bar.h"]),
-                ],
+                deps=[CcTarget(name="foo_pkg", header_files=["foo.h", "some/virtual/dir/bar.h"])],
                 implementation_deps=[CcTarget(name="baz_pkg", header_files=["long/nested/path/baz.h"])],
                 include_paths=["", "long/nested", "some/virtual"],
+                defines=[],
+            ),
+            ensure_private_deps=True,
+        )
+
+        self.assertTrue(result.is_ok())
+
+    def test_success_for_valid_dependencies_with_virtual_include_paths_and_relative_include_statements(self):
+        result = evaluate_includes(
+            public_includes=[
+                Include(file=Path("file1"), include="../../self/own_header.h"),
+                Include(file=Path("file1"), include="some/virtual/../../dir/foo.h"),
+            ],
+            private_includes=[Include(file=Path("file2"), include="some/../../../some/virtual/dir/bar.h")],
+            system_under_inspection=SystemUnderInspection(
+                target_under_inspection=CcTarget(name="self", header_files=["self/own_header.h"]),
+                deps=[CcTarget(name="foo_pkg", header_files=["dir/foo.h"])],
+                implementation_deps=[CcTarget(name="bar_pkg", header_files=["some/virtual/dir/bar.h"])],
+                include_paths=["", "some/virtual", "other/virtual"],
                 defines=[],
             ),
             ensure_private_deps=True,

--- a/test/aspect/relative_includes/use_system_include.cpp
+++ b/test/aspect/relative_includes/use_system_include.cpp
@@ -3,7 +3,8 @@
 #include "some/sub/dir/foo.h"
 #include "some/sub/dir/../dir/bar.h"
 // include from virtually prefixed path
-#include <sub/dir/bar.h>
+#include <sub/../sub/dir/bar.h>
+#include <../some/sub/dir/bar.h>
 
 int main() {
     return useSystemInclude() + doBar() + doFoo();

--- a/test/aspect/relative_includes/use_virtual_prefix.cpp
+++ b/test/aspect/relative_includes/use_virtual_prefix.cpp
@@ -2,8 +2,11 @@
 #include "virtual_prefix.h"
 #include "some/sub/dir/bar.h"
 #include "some/sub/dir/../dir/bar.h"
+// reach into virtual paths from repository root
+#include "test/aspect/relative_includes/_virtual_includes/virtual_prefix/custom/prefix/some/sub/dir/foo.h"
 // include from virtually prefixed path
-#include "custom/prefix/some/sub/dir/foo.h"
+#include "../virtual_prefix/custom/prefix/some/sub/dir/foo.h"
+#include "custom/prefix/../prefix/some/sub/dir/foo.h"
 
 int main() {
     return useVirtualPrefix() + doBar() + doFoo();

--- a/test/aspect/relative_includes/use_virtual_strip.cpp
+++ b/test/aspect/relative_includes/use_virtual_strip.cpp
@@ -2,8 +2,11 @@
 #include "some/virtual_strip.h"
 #include "some/sub/dir/bar.h"
 #include "some/sub/dir/../dir/bar.h"
+// reach into virtual paths from repository root
+#include "test/aspect/relative_includes/_virtual_includes/virtual_strip/sub/dir/foo.h"
 // include from virtually stripped path
-#include "sub/dir/foo.h"
+#include "../virtual_strip/sub/dir/foo.h"
+#include "sub/dir/../dir/foo.h"
 
 int main() {
     return useVirtualStrip() + doBar() + doFoo();


### PR DESCRIPTION
Recent improvements allows us to finally resolve this limitation of DWYU. This is is a niche use case, and doing relative includes to virtual paths is something I would consider a bad practice. Still, given it compiles DWYU should be able to analyze it.