### PR TITLE
Change rationale for manually looking for CcInfo

### DIFF
--- a/src/aspect/dwyu.bzl
+++ b/src/aspect/dwyu.bzl
@@ -135,13 +135,14 @@ def dwyu_aspect_impl(target, ctx):
     Returns:
         OutputGroup containing the generated report file
     """
-    if not ctx.rule.kind in ["cc_binary", "cc_library", "cc_test"]:
+
+    # DWYU is only able to work on targets providing CcInfo. Other targets shall be skipped.
+    # We can't use 'required_providers = [CcInfo],' in the aspect definition due to bug:
+    # https://github.com/bazelbuild/bazel/issues/19609
+    if not CcInfo in target:
         return []
 
-    # Skip incompatible targets
-    # Ideally we should check for the existence of "IncompatiblePlatformProvider".
-    # However, this provider is not available in Starlark
-    if not CcInfo in target:
+    if not ctx.rule.kind in ["cc_binary", "cc_library", "cc_test"]:
         return []
 
     # Skip targets which explicitly opt-out

--- a/src/aspect/factory.bzl
+++ b/src/aspect/factory.bzl
@@ -12,7 +12,7 @@ def dwyu_aspect_factory(
 
     Args:
         config: Configuration file for the tool comparing the include statements to the dependencies.
-        recursive: If true, execute the aspect on all trannsitive dependencies.
+        recursive: If true, execute the aspect on all transitive dependencies.
                    If false, analyze only the target the aspect is being executed on.
         use_implementation_deps: If true, ensure cc_library dependencies which are used only in private files are
                                  listed in implementation_deps. Only available for Bazel >= 5.0.0 and if flag


### PR DESCRIPTION
We have to skip targets not providing CcInfo not just because of incompatible targets in old Bazel versions, but also due to bug: https://github.com/bazelbuild/bazel/issues/19609

Given incompatible targets for aspects have been fixed in recent Bazel versions and the bug above has just been discovered, it makes no sense to keep mentioning incompatible targets as when above bug is fixed and we can remove this manual check for CcInfo incompatible targets are no longer relevant either way.

Resolves: https://github.com/martis42/depend_on_what_you_use/issues/33