### PR TITLE
Update Bazel mypy integration

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -4,6 +4,7 @@ test --test_output=errors
 # Mypy integration
 build:mypy --aspects=@mypy_integration//:mypy.bzl%mypy_aspect
 build:mypy --output_groups=mypy
+build:mypy --@mypy_integration//:mypy=//third_party:mypy
 build:mypy --@mypy_integration//:mypy_config=//:mypy.ini
 
 # Allow users to provide their own workspace settings

--- a/dev_setup_step_2.bzl
+++ b/dev_setup_step_2.bzl
@@ -1,6 +1,6 @@
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
-load("@mypy_integration//repositories:deps.bzl", mypy_deps = "deps")
-load("@mypy_integration//repositories:repositories.bzl", mypy_integration_dependencies = "repositories")
+load("@mypy_integration//repositories:repositories.bzl", mypy_integration_repositories = "repositories")
+load("@rules_python//python:pip.bzl", "pip_parse")
 load("@rules_python//python:repositories.bzl", "python_register_multi_toolchains")
 
 def dev_setup_step_2():
@@ -8,8 +8,13 @@ def dev_setup_step_2():
     Perform the second development setup step.
     """
     bazel_skylib_workspace()
-    mypy_deps("//third_party:mypy_requirements.txt")
-    mypy_integration_dependencies()
+
+    mypy_integration_repositories()
+
+    pip_parse(
+        name = "dwyu_mypy_deps",
+        requirements_lock = "//third_party:mypy_requirements.txt",
+    )
 
     # Choose different version via: --@rules_python//python/config_settings:python_version=X
     python_register_multi_toolchains(

--- a/dev_setup_step_3.bzl
+++ b/dev_setup_step_3.bzl
@@ -1,4 +1,4 @@
-load("@mypy_integration_pip_deps//:requirements.bzl", install_mypy_deps = "install_deps")
+load("@dwyu_mypy_deps//:requirements.bzl", install_mypy_deps = "install_deps")
 
 def dev_setup_step_3():
     """

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -1,4 +1,11 @@
+load("@dwyu_mypy_deps//:requirements.bzl", "requirement")
 load("@rules_python//python:pip.bzl", "compile_pip_requirements")
+
+alias(
+    name = "mypy",
+    actual = requirement("mypy"),
+    visibility = ["//:__pkg__"],
+)
 
 compile_pip_requirements(
     name = "requirements",

--- a/third_party/dev_dependencies.bzl
+++ b/third_party/dev_dependencies.bzl
@@ -2,11 +2,11 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
 def dev_dependencies():
-    version = "4aa11dfdd1958255e133f0d172794d68a0a07b53"
+    version = "0a881be043e8eae72ad83610c6205e7972bcd5e1"
     maybe(
         http_archive,
         name = "mypy_integration",
-        sha256 = "24b717883aec8b2234a8f2780e7ea5ddcd5ebbf59acc2f20ff02b31ac7ad7085",
+        sha256 = "1b6c3b1d967ae87b83b7ec179a376a4ff501925488bb06960545e776a873aebd",
         strip_prefix = "bazel-mypy-integration-{v}".format(v = version),
         urls = ["https://github.com/martis42/bazel-mypy-integration/archive/{v}.tar.gz".format(v = version)],
     )


### PR DESCRIPTION
The latest version decouples the mypy Bazel integration from the mypy library. This eases integrating it into other projects like DWYU.