### PR TITLE
Update rules_python to 0.27.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ dwyu_setup_step_2()
 
 load("@depend_on_what_you_use//:setup_step_3.bzl", dwyu_setup_step_3 = "setup_step_3")
 dwyu_setup_step_3()
+
+load("@depend_on_what_you_use//:setup_step_4.bzl", dwyu_setup_step_4 = "setup_step_4")
+dwyu_setup_step_4()
 ```
 
 ## Use DWYU

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,6 +16,10 @@ load("//:setup_step_3.bzl", "setup_step_3")
 
 setup_step_3()
 
+load("//:setup_step_4.bzl", "setup_step_4")
+
+setup_step_4()
+
 #
 # Setup of development dependencies of this project
 #

--- a/setup_step_2.bzl
+++ b/setup_step_2.bzl
@@ -1,22 +1,14 @@
 load("@bazel_skylib//lib:versions.bzl", "versions")
-load("@rules_python//python:pip.bzl", "pip_parse")
+load("@rules_python//python:repositories.bzl", "py_repositories")
 
 def setup_step_2():
     """
     Perform the second setup step.
     """
 
-    # Strictly speaking we should use one pip_parse per Python version. However, pcpp has no transitive dependencies
-    # and only a single wheel for all Python versions. Thus, we simply use a single resolved requirements file for all
-    # Python versions.
-    # Furthermore, this code is executed by the users of DWYU and we don't want to impose a specific Python interpreter
-    # onto them.
-    pip_parse(
-        name = "dwyu_py_deps",
-        requirements_lock = "@depend_on_what_you_use//third_party:requirements.txt",
-    )
-
     # Fail early for incompatible Bazel versions instead of printing obscure errors from within our implementation
     versions.check(
         minimum_bazel_version = "5.4.0",
     )
+
+    py_repositories()

--- a/setup_step_3.bzl
+++ b/setup_step_3.bzl
@@ -1,8 +1,16 @@
-load("@dwyu_py_deps//:requirements.bzl", install_py_deps = "install_deps")
+load("@rules_python//python:pip.bzl", "pip_parse")
 
 def setup_step_3():
     """
     Perform the third setup step.
     """
 
-    install_py_deps()
+    # Strictly speaking we should use one pip_parse per Python version. However, pcpp has no transitive dependencies
+    # and only a single wheel for all Python versions. Thus, we simply use a single resolved requirements file for all
+    # Python versions.
+    # Furthermore, this code is executed by the users of DWYU and we don't want to impose a specific Python interpreter
+    # onto them.
+    pip_parse(
+        name = "dwyu_py_deps",
+        requirements_lock = "@depend_on_what_you_use//third_party:requirements.txt",
+    )

--- a/setup_step_4.bzl
+++ b/setup_step_4.bzl
@@ -1,0 +1,8 @@
+load("@dwyu_py_deps//:requirements.bzl", install_py_deps = "install_deps")
+
+def setup_step_4():
+    """
+    Perform the fourth setup step.
+    """
+
+    install_py_deps()

--- a/test/apply_fixes/execution_logic.py
+++ b/test/apply_fixes/execution_logic.py
@@ -26,6 +26,9 @@ setup_step_2()
 load("@depend_on_what_you_use//:setup_step_3.bzl", "setup_step_3")
 setup_step_3()
 
+load("@depend_on_what_you_use//:setup_step_4.bzl", "setup_step_4")
+setup_step_4()
+
 {extra_content}
 """
 

--- a/third_party/dependencies.bzl
+++ b/third_party/dependencies.bzl
@@ -2,13 +2,13 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
 def dependencies():
-    rules_python_version = "0.25.0"
+    rules_python_version = "0.27.0"
     maybe(
         http_archive,
         name = "rules_python",
-        sha256 = "5868e73107a8e85d8f323806e60cad7283f34b32163ea6ff1020cf27abef6036",
+        sha256 = "9acc0944c94adb23fba1c9988b48768b1bacc6583b52a2586895c5b7491e2e31",
         strip_prefix = "rules_python-{}".format(rules_python_version),
-        urls = ["https://github.com/bazelbuild/rules_python/archive/{}.tar.gz".format(rules_python_version)],
+        urls = ["https://github.com/bazelbuild/rules_python/releases/download/{v}/rules_python-{v}.tar.gz".format(v = rules_python_version)],
     )
 
     skylib_version = "1.5.0"


### PR DESCRIPTION
rules_python develops at a steady pace and we want to keep our toolchain up to date. Also, we want to start supporting bzlmod soon, which profits from using a recent rules_python version.