### PR TITLE
Rename the DWYU output group

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ your_dwyu_aspect = dwyu_aspect_factory()
 ### Use the aspect
 
 Invoke the aspect through the command line on a target:<br>
-`bazel build <target_pattern> --aspects=//:aspect.bzl%your_dwyu_aspect --output_groups=cc_dwyu_output`
+`bazel build <target_pattern> --aspects=//:aspect.bzl%your_dwyu_aspect --output_groups=dwyu`
 
 If no problem is found, the command will exit with `INFO: Build completed successfully`.<br>
 If a problem is detected, the build command will fail with an error and a description of the problem will be printed in the terminal. For example:

--- a/src/aspect/dwyu.bzl
+++ b/src/aspect/dwyu.bzl
@@ -159,9 +159,9 @@ def _gather_transitive_reports(ctx):
     """
     reports = []
     if ctx.attr._recursive:
-        reports.extend([dep[OutputGroupInfo].cc_dwyu_output for dep in ctx.rule.attr.deps])
+        reports.extend([dep[OutputGroupInfo].dwyu for dep in ctx.rule.attr.deps])
         if hasattr(ctx.rule.attr, "implementation_deps"):
-            reports.extend([dep[OutputGroupInfo].cc_dwyu_output for dep in ctx.rule.attr.implementation_deps])
+            reports.extend([dep[OutputGroupInfo].dwyu for dep in ctx.rule.attr.implementation_deps])
     return reports
 
 def dwyu_aspect_impl(target, ctx):
@@ -238,4 +238,4 @@ def dwyu_aspect_impl(target, ctx):
     )
 
     accumulated_reports = depset(direct = [report_file], transitive = _gather_transitive_reports(ctx))
-    return [OutputGroupInfo(cc_dwyu_output = accumulated_reports)]
+    return [OutputGroupInfo(dwyu = accumulated_reports)]

--- a/test/apply_fixes/test_case.py
+++ b/test/apply_fixes/test_case.py
@@ -67,7 +67,7 @@ class TestCaseBase(ABC):
         cmd = ["bazel"]
         if startup_args:
             cmd.extend(startup_args)
-        cmd.extend(["build", f"--aspects=//:aspect.bzl%{aspect}", "--output_groups=cc_dwyu_output"])
+        cmd.extend(["build", f"--aspects=//:aspect.bzl%{aspect}", "--output_groups=dwyu"])
         if extra_args:
             cmd.extend(extra_args)
         cmd.append(self.test_target)

--- a/test/aspect/execute_tests_impl.py
+++ b/test/aspect/execute_tests_impl.py
@@ -176,7 +176,7 @@ def bazel_binary() -> str:
 def make_cmd(test_cmd: TestCmd, startup_args: List[str], extra_args: List[str]) -> List[str]:
     cmd = [bazel_binary()] + startup_args + ["build", "--noshow_progress"]
     if test_cmd.aspect:
-        cmd.extend([f"--aspects={test_cmd.aspect}", "--output_groups=cc_dwyu_output"])
+        cmd.extend([f"--aspects={test_cmd.aspect}", "--output_groups=dwyu"])
     cmd.extend(extra_args)
     cmd.extend(test_cmd.extra_args)
     cmd.append("--")

--- a/test/aspect/execute_tests_utest.py
+++ b/test/aspect/execute_tests_utest.py
@@ -190,7 +190,7 @@ class TestMakeCmd(unittest.TestCase):
         self.assertEqual(
             cmd,
             self._base_cmd()
-            + ["--aspects=//some/aspect.bzl", "--output_groups=cc_dwyu_output", "--abc", "--cba", "--", "//foo:bar"],
+            + ["--aspects=//some/aspect.bzl", "--output_groups=dwyu", "--abc", "--cba", "--", "//foo:bar"],
         )
 
     def test_extra_args_on_top_of_test_cmd(self):
@@ -208,7 +208,7 @@ class TestMakeCmd(unittest.TestCase):
             self._base_cmd(startup_args=["--some_startup_arg"])
             + [
                 "--aspects=//some/aspect.bzl",
-                "--output_groups=cc_dwyu_output",
+                "--output_groups=dwyu",
                 "--outside_arg",
                 "--test_related_arg",
                 "--",

--- a/test/aspect/recursion/rule.bzl
+++ b/test/aspect/recursion/rule.bzl
@@ -3,7 +3,7 @@ load("//test/aspect/recursion:aspect.bzl", "recursive_aspect", "recursive_impl_d
 
 def _dwyu_rule_impl(ctx):
     # gather artifacts to make sure the aspect is executed
-    aspect_artifacts = depset(transitive = [dep[OutputGroupInfo].cc_dwyu_output for dep in ctx.attr.deps])
+    aspect_artifacts = depset(transitive = [dep[OutputGroupInfo].dwyu for dep in ctx.attr.deps])
     return [DefaultInfo(files = aspect_artifacts)]
 
 dwyu_rule_direct = rule(


### PR DESCRIPTION
There is no strong reason for this change. I am however not happy with the name chosen by me in the early project phase. Since, version 0.1.0 will soonish happen (aka jumping from alpha status to beta level) I want to do this breaking change now, before the project enters a phase in which such changes no longer should happen without strong reasons. Some concrete issues with the old name:
- The `cc_` prefix does not provide any meaningful information
- The `_output` postfix is redundant for something used with `--output_groups`