### PR TITLE
Replace dependabot with renovate

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":rebaseStalePrs",
+    "schedule:weekends"
+  ],
+  "labels": [
+    "deps"
+  ],
+  "dependencyDashboard": true,
+  "pre-commit": {
+    "enabled": true
+  },
+  "enabledManagers": [
+    "github-actions",
+    "poetry",
+    "pre-commit"
+  ]
+}


### PR DESCRIPTION
Renovate supports Bazel (although we don't use it for now) and pre-commit updates which dependabot does not. GitHub Actions can be managed by both.