### PR TITLE
Update minimum Python version for development to 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = ""
 authors = ["Martin Medler"]
 
 [tool.poetry.dependencies]
-python = "^3.8.1"
+python = "^3.9.0"
 
 [tool.poetry.dev-dependencies]
 pre-commit = "^3.5.0"


### PR DESCRIPTION
This does not change the minimum Python version DWYU supports in production. This only raises the minimum version required to be able to develop DWYU due to pre-commit deprecating Python 3.8 support early.