### PR TITLE
Explicitly use pre-commit 3.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["Martin Medler"]
 python = "^3.9.0"
 
 [tool.poetry.dev-dependencies]
-pre-commit = "^3.5.0"
+pre-commit = "3.6.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
Saying >= 3.5 or newer sounds great at first, but actually it makes it hard to know what pre-commit version we actually use. The lock file pins to the latest version greater 3.5 at whatever time the lock was created. Thus, we pin pre-commit, but to know what we pin it to, one has to look into the longish lock file whereas one would expect the information in the pyprojects.toml file.