### PR TITLE
Test examples with both workspace modi

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -7,11 +7,11 @@ test --test_output=errors
 # yanking a module). Furthermore, the module resolution is deterministic.
 # However, there are several open issues suggesting the lock file will change in one way or another.
 # Thus, we don't use the bzlmod locking yet.
-build --lockfile_mode=off
+common --lockfile_mode=off
 
 # When working with hermetic Python toolchains, supporting the legacy runfiles layout is needlessly wasting resources.
 # See https://github.com/bazelbuild/rules_python/issues/1653
-build --nolegacy_external_runfiles
+common --nolegacy_external_runfiles
 
 # Mypy integration
 build:mypy --aspects=@mypy_integration//:mypy.bzl%mypy_aspect

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,3 +61,7 @@ jobs:
         run: |
           cd examples
           ./test.py
+      - name: Integration tests - Examples with legacy WORKSPACE setup
+        run: |
+          cd examples
+          ./test.py --legacy-workspace

--- a/examples/.bazelrc
+++ b/examples/.bazelrc
@@ -12,6 +12,3 @@ build --experimental_convenience_symlinks=clean
 # However, there are several open issues suggesting the lock file will change in one way or another.
 # Thus, we don't use the bzlmod locking yet.
 build --lockfile_mode=off
-
-# bzlmod changed how repos interact with each other which is incompatible to current DWYU design
-build --enable_bzlmod=false

--- a/examples/.bazelrc
+++ b/examples/.bazelrc
@@ -1,9 +1,9 @@
 # When working with hermetic Python toolchains, supporting the legacy runfiles layout is needlessly wasting resources.
 # See https://github.com/bazelbuild/rules_python/issues/1653
-build --nolegacy_external_runfiles
+common --nolegacy_external_runfiles
 
 # The symlinks are annoying
-build --experimental_convenience_symlinks=clean
+common --experimental_convenience_symlinks=clean
 
 # The performance gains offered by the lockfile are minimal for us.
 # Pinning the dependencies should be superfluous from a reproducibility perspective as the central registry is supposed
@@ -11,4 +11,4 @@ build --experimental_convenience_symlinks=clean
 # yanking a module). Furthermore, the module resolution is deterministic.
 # However, there are several open issues suggesting the lock file will change in one way or another.
 # Thus, we don't use the bzlmod locking yet.
-build --lockfile_mode=off
+common --lockfile_mode=off

--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -13,6 +13,11 @@ local_path_override(
     path = "../",
 )
 
+#
+# One can use DWYU without the content below. The hermetic Python toolchain merely increases the reproducibility when
+# executing the examples as integration test.
+#
+
 bazel_dep(
     name = "rules_python",
     version = "0.27.0",
@@ -25,5 +30,5 @@ python = use_extension(
     dev_dependency = True,
 )
 python.toolchain(
-    python_version = "3.10",
+    python_version = "3.8",
 )

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -13,6 +13,11 @@ load("@depend_on_what_you_use//:setup_step_2.bzl", "setup_step_2")
 
 setup_step_2()
 
+#
+# One can use DWYU without the content below. The hermetic Python toolchain merely increases the reproducibility when
+# executing the examples as integration test.
+#
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
@@ -28,5 +33,5 @@ load("@rules_python//python:repositories.bzl", "python_register_toolchains")
 
 python_register_toolchains(
     name = "python",
-    python_version = "3.10",
+    python_version = "3.8",
 )

--- a/examples/aspect.bzl
+++ b/examples/aspect.bzl
@@ -5,8 +5,8 @@ dwyu = dwyu_aspect_factory(use_implementation_deps = True)
 dwyu_recursive = dwyu_aspect_factory(recursive = True)
 dwyu_custom_skipping = dwyu_aspect_factory(skipped_tags = ["my_tag"])
 
-# FIXME does not work with bzlmod
-dwyu_ignoring_includes = dwyu_aspect_factory(ignored_includes = "@//ignoring_includes:ignore_includes.json")
-dwyu_map_specific_deps = dwyu_aspect_factory(target_mapping = "@//target_mapping/mapping:map_specific_deps")
-dwyu_map_direct_deps = dwyu_aspect_factory(target_mapping = "@//target_mapping/mapping:map_direct_deps")
-dwyu_map_transitive_deps = dwyu_aspect_factory(target_mapping = "@//target_mapping/mapping:map_transitive_deps")
+# We need to explicitly pass labels as passing strings does not work with a bzlmod setup.
+dwyu_ignoring_includes = dwyu_aspect_factory(ignored_includes = Label("@//ignoring_includes:ignore_includes.json"))
+dwyu_map_specific_deps = dwyu_aspect_factory(target_mapping = Label("@//target_mapping/mapping:map_specific_deps"))
+dwyu_map_direct_deps = dwyu_aspect_factory(target_mapping = Label("@//target_mapping/mapping:map_direct_deps"))
+dwyu_map_transitive_deps = dwyu_aspect_factory(target_mapping = Label("@//target_mapping/mapping:map_transitive_deps"))

--- a/examples/test.py
+++ b/examples/test.py
@@ -4,6 +4,7 @@ import logging
 import shlex
 import subprocess
 import sys
+from argparse import ArgumentParser
 from dataclasses import dataclass
 
 logging.basicConfig(format="%(message)s", level=logging.INFO)
@@ -11,65 +12,65 @@ logging.basicConfig(format="%(message)s", level=logging.INFO)
 
 @dataclass
 class Example:
-    cmd: str
+    build_cmd: str
     expected_success: bool
 
 
 EXAMPLES = [
     Example(
-        cmd="bazel build --aspects=//:aspect.bzl%dwyu --output_groups=dwyu //basic_usage:correct_dependencies",
+        build_cmd="--aspects=//:aspect.bzl%dwyu --output_groups=dwyu //basic_usage:correct_dependencies",
         expected_success=True,
     ),
     Example(
-        cmd="bazel build --aspects=//:aspect.bzl%dwyu --output_groups=dwyu //basic_usage:false_dependencies",
+        build_cmd="--aspects=//:aspect.bzl%dwyu --output_groups=dwyu //basic_usage:false_dependencies",
         expected_success=False,
     ),
     Example(
-        cmd="bazel build --aspects=//:aspect.bzl%dwyu --output_groups=dwyu //basic_usage:not_using_lib",
+        build_cmd="--aspects=//:aspect.bzl%dwyu --output_groups=dwyu //basic_usage:not_using_lib",
         expected_success=False,
     ),
     Example(
-        cmd="bazel build --aspects=//:aspect.bzl%dwyu_ignoring_includes --output_groups=dwyu //ignoring_includes:use_unavailable_headers",
+        build_cmd="--aspects=//:aspect.bzl%dwyu_ignoring_includes --output_groups=dwyu //ignoring_includes:use_unavailable_headers",
         expected_success=True,
     ),
     Example(
-        cmd="bazel build --aspects=//:aspect.bzl%dwyu --output_groups=dwyu //recursion:use_lib",
+        build_cmd="--aspects=//:aspect.bzl%dwyu --output_groups=dwyu //recursion:use_lib",
         expected_success=True,
     ),
     Example(
-        cmd="bazel build --aspects=//:aspect.bzl%dwyu_recursive --output_groups=dwyu //recursion:use_lib",
+        build_cmd="--aspects=//:aspect.bzl%dwyu_recursive --output_groups=dwyu //recursion:use_lib",
         expected_success=False,
     ),
     Example(
-        cmd="bazel build //rule_using_dwyu/...",
+        build_cmd="//rule_using_dwyu/...",
         expected_success=False,
     ),
     Example(
-        cmd="bazel build --aspects=//:aspect.bzl%dwyu --output_groups=dwyu //skipping_targets:bad_target",
+        build_cmd="--aspects=//:aspect.bzl%dwyu --output_groups=dwyu //skipping_targets:bad_target",
         expected_success=False,
     ),
     Example(
-        cmd="bazel build --aspects=//:aspect.bzl%dwyu --output_groups=dwyu //skipping_targets:bad_target_skipped",
+        build_cmd="--aspects=//:aspect.bzl%dwyu --output_groups=dwyu //skipping_targets:bad_target_skipped",
         expected_success=True,
     ),
     Example(
-        cmd="bazel build --aspects=//:aspect.bzl%dwyu_custom_skipping --output_groups=dwyu //skipping_targets:bad_target_custom_skip",
+        build_cmd="--aspects=//:aspect.bzl%dwyu_custom_skipping --output_groups=dwyu //skipping_targets:bad_target_custom_skip",
         expected_success=True,
     ),
     Example(
-        cmd="bazel build --aspects=//:aspect.bzl%dwyu_map_specific_deps --output_groups=dwyu //target_mapping:use_lib_b",
+        build_cmd="--aspects=//:aspect.bzl%dwyu_map_specific_deps --output_groups=dwyu //target_mapping:use_lib_b",
         expected_success=True,
     ),
     Example(
-        cmd="bazel build --aspects=//:aspect.bzl%dwyu_map_direct_deps --output_groups=dwyu //target_mapping:use_lib_b",
+        build_cmd="--aspects=//:aspect.bzl%dwyu_map_direct_deps --output_groups=dwyu //target_mapping:use_lib_b",
         expected_success=True,
     ),
     Example(
-        cmd="bazel build --aspects=//:aspect.bzl%dwyu_map_direct_deps --output_groups=dwyu //target_mapping:use_lib_c",
+        build_cmd="--aspects=//:aspect.bzl%dwyu_map_direct_deps --output_groups=dwyu //target_mapping:use_lib_c",
         expected_success=False,
     ),
     Example(
-        cmd="bazel build --aspects=//:aspect.bzl%dwyu_map_transitive_deps --output_groups=dwyu //target_mapping:use_lib_c",
+        build_cmd="--aspects=//:aspect.bzl%dwyu_map_transitive_deps --output_groups=dwyu //target_mapping:use_lib_c",
         expected_success=True,
     ),
 ]
@@ -81,25 +82,45 @@ class Result:
     success: bool
 
 
-def execute_example(example: Example) -> Result:
-    logging.info(f"\n##\n## Executing: {example.cmd}\n##\n")
+def make_cmd(example: Example, legacy_workspace: bool) -> str:
+    cmd = "bazel build "
+    if legacy_workspace:
+        cmd += "--noenable_bzlmod "
+    cmd += example.build_cmd
+    return cmd
 
-    process = subprocess.run(shlex.split(example.cmd), check=False)
+
+def execute_example(example: Example, legacy_workspace: bool) -> Result:
+    cmd = make_cmd(example=example, legacy_workspace=legacy_workspace)
+    logging.info(f"\n##\n## Executing: {cmd}\n##\n")
+
+    process = subprocess.run(shlex.split(cmd), check=False)
     if (process.returncode == 0 and example.expected_success) or (
         process.returncode != 0 and not example.expected_success
     ):
-        return Result(example=example.cmd, success=True)
-    return Result(example=example.cmd, success=False)
+        return Result(example=cmd, success=True)
+    return Result(example=cmd, success=False)
 
 
-def main() -> int:
+def cli():
+    parser = ArgumentParser()
+    parser.add_argument(
+        "--legacy-workspace",
+        "-w",
+        action="store_true",
+        help="Use the WORKSPACE file based project setup instead of bzlmod.",
+    )
+    return parser.parse_args()
+
+
+def main(legacy_workspace: bool) -> int:
     """
     Basic testing if the examples behave as desired.
 
     We ony look for the return code of a command. If a command fails as expected we do not analyze if it fails for the
     correct reason. These kind of detailed testing is done in the integration tests.
     """
-    results = [execute_example(ex) for ex in EXAMPLES]
+    results = [execute_example(example=ex, legacy_workspace=legacy_workspace) for ex in EXAMPLES]
     failed_examples = [res.example for res in results if not res.success]
 
     if failed_examples:
@@ -112,4 +133,5 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    args = cli()
+    sys.exit(main(args.legacy_workspace))

--- a/test/aspect/ignore_includes/aspect.bzl
+++ b/test/aspect/ignore_includes/aspect.bzl
@@ -1,5 +1,5 @@
 load("//:defs.bzl", "dwyu_aspect_factory")
 
-ignore_include_paths_aspect = dwyu_aspect_factory(ignored_includes = "//test/aspect/ignore_includes:ignore_include_paths.json")
-extra_ignore_include_paths_aspect = dwyu_aspect_factory(ignored_includes = "//test/aspect/ignore_includes:extra_ignore_include_paths.json")
-extra_ignore_include_patterns_aspect = dwyu_aspect_factory(ignored_includes = "//test/aspect/ignore_includes:ignore_include_patterns.json")
+ignore_include_paths_aspect = dwyu_aspect_factory(ignored_includes = Label("//test/aspect/ignore_includes:ignore_include_paths.json"))
+extra_ignore_include_paths_aspect = dwyu_aspect_factory(ignored_includes = Label("//test/aspect/ignore_includes:extra_ignore_include_paths.json"))
+extra_ignore_include_patterns_aspect = dwyu_aspect_factory(ignored_includes = Label("//test/aspect/ignore_includes:ignore_include_patterns.json"))

--- a/test/aspect/target_mapping/aspect.bzl
+++ b/test/aspect/target_mapping/aspect.bzl
@@ -1,5 +1,5 @@
 load("//:defs.bzl", "dwyu_aspect_factory")
 
-map_specific_deps = dwyu_aspect_factory(target_mapping = "//test/aspect/target_mapping/mapping:map_specific_deps")
-map_direct_deps = dwyu_aspect_factory(target_mapping = "//test/aspect/target_mapping/mapping:map_direct_deps")
-map_transitive_deps = dwyu_aspect_factory(target_mapping = "//test/aspect/target_mapping/mapping:map_transitive_deps")
+map_specific_deps = dwyu_aspect_factory(target_mapping = Label("//test/aspect/target_mapping/mapping:map_specific_deps"))
+map_direct_deps = dwyu_aspect_factory(target_mapping = Label("//test/aspect/target_mapping/mapping:map_direct_deps"))
+map_transitive_deps = dwyu_aspect_factory(target_mapping = Label("//test/aspect/target_mapping/mapping:map_transitive_deps"))

--- a/tests.sh
+++ b/tests.sh
@@ -27,3 +27,14 @@ echo ""
 echo "Execute interation tests - Applying fixes"
 echo ""
 ./test/apply_fixes/execute_tests.py
+
+echo ""
+echo "Execute interation tests - Examples with bzlmod"
+echo ""
+cd examples
+./test.py
+
+echo ""
+echo "Execute interation tests - Examples with WORKSPACE setup"
+echo ""
+./test.py --legacy-workspace


### PR DESCRIPTION
We need to provide targets from the root workspace to DWYU explicitly with labels as auto generating labels from strings does not work with bzlmod. With bzlmod the strings are converted in the wrong context to a label and thus cause visibility errors.