### PR TITLE
Remove CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
-[![CI](https://github.com/martis42/depend_on_what_you_use/actions/workflows/ci.yaml/badge.svg)](https://github.com/martis42/depend_on_what_you_use/actions/workflows/ci.yaml)
 
 - [Depend on what you use (DWYU)](#depend-on-what-you-use-dwyu)
 - [Getting started](#getting-started)


### PR DESCRIPTION
We are only interested in showing all tests are green. This is however not possible due to always showing the latest result, which could be from a speculative test PR.
Also we configured the CI as gating, meaning nothing can be red either way unless we explicitly disable the CI.