### PR TITLE
Make aspect integrations tests wotk on Windows 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,16 +42,23 @@ jobs:
   integration-tests-aspect:
     strategy:
       matrix:
-        os: [ ubuntu-22.04, macos-12 ]
+        os: [ ubuntu-22.04, macos-12, windows-2022 ]
     runs-on: ${{ matrix.os }}
     needs: [ fast-tests ]
     steps:
       - uses: actions/checkout@v4
       - name: Integration tests - Aspect
+        if: runner.os != 'Windows'
         run: |
           cd test
           cd aspect
           python execute_tests.py
+      - name: Integration tests - Aspect
+        if: runner.os == 'Windows'
+        run: |
+          cd test
+          cd aspect
+          python execute_tests.py -b 7.0.0 -p 3.8.18
 
   integration-tests-apply-fixes:
     runs-on: ubuntu-22.04

--- a/src/aspect/dwyu.bzl
+++ b/src/aspect/dwyu.bzl
@@ -76,12 +76,15 @@ def extract_defines_from_compiler_flags(compiler_flags):
     defines = {}
 
     for cflag in compiler_flags:
-        if cflag.startswith("-U"):
+        # gcc/clang use '-U'. MSVC uses '/U'.
+        if cflag.startswith(("-U", "/U")):
             undefine = cflag[2:]
             undefine_name = undefine.split("=", 1)[0]
             if undefine_name in defines.keys():
                 defines.pop(undefine_name)
-        if cflag.startswith("-D"):
+
+        # gcc/clang use '-D'. MSVC uses '/D'.
+        if cflag.startswith(("-D", "/D")):
             define = cflag[2:]
             define_name = define.split("=", 1)[0]
             defines[define_name] = define

--- a/src/aspect/test/dwyu_test.bzl
+++ b/src/aspect/test/dwyu_test.bzl
@@ -29,6 +29,13 @@ def _extract_defines_from_compiler_flags_test_impl(ctx):
         extract_defines_from_compiler_flags(["-DFoo=BAR=42", "-DTick 42", '-DRiff "Raff"']),
     )
 
+    # MSVC syntax
+    asserts.equals(
+        env,
+        ["Bar", "FooBar=42"],
+        extract_defines_from_compiler_flags(["/DFoo", "/UFoo", "/DBar", "/DFooBar=42"]),
+    )
+
     return unittest.end(env)
 
 extract_defines_from_compiler_flags_test = unittest.make(_extract_defines_from_compiler_flags_test_impl)

--- a/test/aspect/alias/test_invalid_dependency_through_alias.py
+++ b/test/aspect/alias/test_invalid_dependency_through_alias.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from result import ExpectedResult, Result
 from test_case import TestCaseBase
 
@@ -6,7 +8,7 @@ class TestCase(TestCaseBase):
     def execute_test_logic(self) -> Result:
         expected = ExpectedResult(
             success=False,
-            invalid_includes=["File='alias/use_a_and_b.cpp', include='alias/a.h'"],
+            invalid_includes=[f"File='{Path('alias/use_a_and_b.cpp')}', include='alias/a.h'"],
         )
         actual = self._run_dwyu(target="//alias:use_a_transitively", aspect=self.default_aspect)
 

--- a/test/aspect/defines/BUILD
+++ b/test/aspect/defines/BUILD
@@ -7,7 +7,11 @@ cc_library(
 cc_library(
     name = "defines_from_bazel_target",
     hdrs = ["defines_from_bazel_target.h"],
-    copts = ["-DSOME_COPT 42"],
+    copts = select({
+        # Strictly speaking Windows does not automatically equal MSVC, but does so in our integration tests
+        "@platforms//os:windows": ["/DSOME_COPT 42"],
+        "//conditions:default": ["-DSOME_COPT 42"],
+    }),
     defines = ["SOME_DEFINE"],
     local_defines = ["LOCAL_DEFINE"],
     deps = ["//defines/support:lib_a"],

--- a/test/aspect/defines/defines_from_bazel_target.h
+++ b/test/aspect/defines/defines_from_bazel_target.h
@@ -1,17 +1,17 @@
 #ifdef SOME_DEFINE
 #include "defines/support/a.h"
 #else
-#include "defines/support/b.h"
+#include "non/existing/a.h"
 #endif
 
 #ifdef LOCAL_DEFINE
 #include "defines/support/a.h"
 #else
-#include "defines/support/b.h"
+#include "non/existing/b.h"
 #endif
 
 #if SOME_COPT > 40
 #include "defines/support/a.h"
 #else
-#include "defines/support/b.h"
+#include "non/existing/c.h"
 #endif

--- a/test/aspect/defines/transitive_defines_from_bazel_target.h
+++ b/test/aspect/defines/transitive_defines_from_bazel_target.h
@@ -3,7 +3,7 @@
 #ifdef TRANSITIVE_DEFINE
 #include "defines/support/a.h"
 #else
-#include "defines/support/b.h"
+#include "non/existing/a.h"
 #endif
 
 #include "defines/support/a.h"
@@ -13,9 +13,9 @@
 // 'local_defines' which should not leak to users of the target
 
 #ifdef LOCAL_DEFINE
-#include "defines/support/b.h"
+#include "non/existing/b.h"
 #endif
 
 #ifdef LOCAL_COPT
-#include "defines/support/b.h"
+#include "non/existing/c.h"
 #endif

--- a/test/aspect/execution_logic.py
+++ b/test/aspect/execution_logic.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 import subprocess
 from importlib.machinery import SourceFileLoader
-from os import environ
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -75,7 +74,7 @@ def main(
     versions = [TestedVersions(bazel=bazel, python=python)] if bazel and python else tested_versions
 
     failed_tests = []
-    output_root = Path(environ["HOME"]) / ".cache" / "bazel" / workspace_path.relative_to("/")
+    output_root = Path.home() / ".cache" / "bazel" / "dwyu"
     for version in versions:
         output_base = output_root / f"aspect_integration_tests_bazel_{version.bazel}_python_{version.python}"
         output_base.mkdir(parents=True, exist_ok=True)

--- a/test/aspect/ignore_includes/test_include_not_covered_by_patterns.py
+++ b/test/aspect/ignore_includes/test_include_not_covered_by_patterns.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from result import ExpectedResult, Result
 from test_case import TestCaseBase
 
@@ -7,7 +9,7 @@ class TestCase(TestCaseBase):
         expected = ExpectedResult(
             success=False,
             invalid_includes=[
-                "File='ignore_includes/use_not_ignored_header.h', include='example_substring_matching_does_not_work_here.h'"
+                f"File='{Path('ignore_includes/use_not_ignored_header.h')}', include='example_substring_matching_does_not_work_here.h'"
             ],
         )
         actual = self._run_dwyu(

--- a/test/aspect/target_mapping/test_use_c_with_direct_deps_mapping.py
+++ b/test/aspect/target_mapping/test_use_c_with_direct_deps_mapping.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from result import ExpectedResult, Result
 from test_case import TestCaseBase
 
@@ -6,7 +8,7 @@ class TestCase(TestCaseBase):
     def execute_test_logic(self) -> Result:
         expected = ExpectedResult(
             success=False,
-            invalid_includes=["File='target_mapping/use_lib_c.cpp', include='target_mapping/libs/c.h'"],
+            invalid_includes=[f"File='{Path('target_mapping/use_lib_c.cpp')}', include='target_mapping/libs/c.h'"],
             unused_public_deps=["//target_mapping/libs:a"],
         )
         actual = self._run_dwyu(

--- a/test/aspect/target_mapping/test_use_c_with_specific_mapping.py
+++ b/test/aspect/target_mapping/test_use_c_with_specific_mapping.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from result import ExpectedResult, Result
 from test_case import TestCaseBase
 
@@ -6,7 +8,7 @@ class TestCase(TestCaseBase):
     def execute_test_logic(self) -> Result:
         expected = ExpectedResult(
             success=False,
-            invalid_includes=["File='target_mapping/use_lib_c.cpp', include='target_mapping/libs/c.h'"],
+            invalid_includes=[f"File='{Path('target_mapping/use_lib_c.cpp')}', include='target_mapping/libs/c.h'"],
             unused_public_deps=["//target_mapping/libs:a"],
         )
         actual = self._run_dwyu(

--- a/test/aspect/tree_artifact/test_invalid_tree_artifact.py
+++ b/test/aspect/tree_artifact/test_invalid_tree_artifact.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from result import ExpectedResult, Result
 from test_case import TestCaseBase
 
@@ -7,7 +9,9 @@ class TestCase(TestCaseBase):
         expected = ExpectedResult(
             success=False,
             # We omit "File='bazel-out/<compilation_mode_and_platform> to allow testing in various environments
-            invalid_includes=["/bin/tree_artifact/sources.cc/tree_lib.cc', include='tree_artifact/some_lib.h'"],
+            invalid_includes=[
+                f"{Path('/bin/tree_artifact/sources.cc/tree_lib.cc')}', include='tree_artifact/some_lib.h'"
+            ],
         )
         actual = self._run_dwyu(
             target="//tree_artifact:tree_artifact_library",

--- a/test/aspect/using_transitive_dep/test_detect_using_transitive_dep.py
+++ b/test/aspect/using_transitive_dep/test_detect_using_transitive_dep.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from result import ExpectedResult, Result
 from test_case import TestCaseBase
 
@@ -6,7 +8,7 @@ class TestCase(TestCaseBase):
     def execute_test_logic(self) -> Result:
         expected = ExpectedResult(
             success=False,
-            invalid_includes=["File='using_transitive_dep/main.cpp', include='using_transitive_dep/foo.h'"],
+            invalid_includes=[f"File='{Path('using_transitive_dep/main.cpp')}', include='using_transitive_dep/foo.h'"],
         )
         actual = self._run_dwyu(target="//using_transitive_dep:main", aspect=self.default_aspect)
 

--- a/test/aspect/using_transitive_dep/test_detect_using_transitive_impl_dep.py
+++ b/test/aspect/using_transitive_dep/test_detect_using_transitive_impl_dep.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from result import ExpectedResult, Result
 from test_case import TestCaseBase
 
@@ -7,7 +9,7 @@ class TestCase(TestCaseBase):
         expected = ExpectedResult(
             success=False,
             invalid_includes=[
-                "File='using_transitive_dep/transitive_usage_through_impl_deps.h', include='using_transitive_dep/foo.h'"
+                f"File='{Path('using_transitive_dep/transitive_usage_through_impl_deps.h')}', include='using_transitive_dep/foo.h'"
             ],
         )
         actual = self._run_dwyu(


### PR DESCRIPTION
For now we execute the Windows based tests only for one Bazel and Python version as executing Python target on Windows is dramatically slow compared to Linux.