### PR TITLE
Downgrade rules python to 0.27.1

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,7 @@
   "extends": [
     "config:recommended",
     ":rebaseStalePrs",
-    "schedule:weekends",
+    "schedule:monthly",
     ":semanticCommits"
   ],
   "labels": [
@@ -31,6 +31,23 @@
         "bazel-module"
       ],
       "enabled": false
+    },
+    {
+      "matchManagers": [
+        "bazel",
+        "bazel-module"
+      ],
+      "groupName": "Bazel dependencies",
+      "groupSlug": "bazel_deps"
+    },
+    {
+      "matchManagers": [
+        "pip_requirements",
+        "poetry",
+        "pre-commit"
+      ],
+      "groupName": "Quality tooling dependencies",
+      "groupSlug": "quality_deps"
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,5 +20,17 @@
     "pip_requirements",
     "poetry",
     "pre-commit"
+  ],
+  "packageRules": [
+    {
+      "matchPackagePatterns": [
+        "rules_python"
+      ],
+      "matchManagers": [
+        "bazel",
+        "bazel-module"
+      ],
+      "enabled": false
+    }
   ]
 }

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -21,7 +21,7 @@ bazel_dep(
     # Keep in sync with //examples/MODULE.bazel
     # Keep in sync with //test/aspect/MODULE.bazel
     # Keep in sync with //test/apply_fixes/execution_logic.py
-    version = "0.28.0",
+    version = "0.27.1",
 )
 
 non_module_dependencies = use_extension(

--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -21,7 +21,7 @@ local_path_override(
 bazel_dep(
     name = "rules_python",
     # Keep in sync with //examples/WORKSPACE
-    version = "0.28.0",
+    version = "0.27.1",
     dev_dependency = True,
 )
 

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -25,9 +25,9 @@ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 maybe(
     http_archive,
     name = "rules_python",
-    sha256 = "d70cd72a7a4880f0000a6346253414825c19cdd40a28289bdf67b8e6480edff8",
-    strip_prefix = "rules_python-0.28.0",
-    urls = ["https://github.com/bazelbuild/rules_python/releases/download/0.28.0/rules_python-0.28.0.tar.gz"],
+    sha256 = "e85ae30de33625a63eca7fc40a94fea845e641888e52f32b6beea91e8b1b2793",
+    strip_prefix = "rules_python-0.27.1",
+    urls = ["https://github.com/bazelbuild/rules_python/releases/download/0.27.1/rules_python-0.27.1.tar.gz"],
 )
 
 load("@rules_python//python:repositories.bzl", "python_register_toolchains")

--- a/test/apply_fixes/execution_logic.py
+++ b/test/apply_fixes/execution_logic.py
@@ -35,9 +35,9 @@ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 maybe(
     http_archive,
     name = "rules_python",
-    sha256 = "d70cd72a7a4880f0000a6346253414825c19cdd40a28289bdf67b8e6480edff8",
-    strip_prefix = "rules_python-0.28.0",
-    urls = ["https://github.com/bazelbuild/rules_python/releases/download/0.28.0/rules_python-0.28.0.tar.gz"],
+    sha256 = "e85ae30de33625a63eca7fc40a94fea845e641888e52f32b6beea91e8b1b2793",
+    strip_prefix = "rules_python-0.27.1",
+    urls = ["https://github.com/bazelbuild/rules_python/releases/download/0.27.1/rules_python-0.27.1.tar.gz"],
 )
 
 load("@rules_python//python:repositories.bzl", "python_register_toolchains")

--- a/test/aspect/MODULE.bazel
+++ b/test/aspect/MODULE.bazel
@@ -20,7 +20,7 @@ local_path_override(
 # Keep in sync with //test/aspect/WORKSPACE
 bazel_dep(
     name = "rules_python",
-    version = "0.28.0",
+    version = "0.27.1",
     dev_dependency = True,
 )
 

--- a/test/aspect/WORKSPACE
+++ b/test/aspect/WORKSPACE
@@ -24,9 +24,9 @@ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 maybe(
     http_archive,
     name = "rules_python",
-    sha256 = "d70cd72a7a4880f0000a6346253414825c19cdd40a28289bdf67b8e6480edff8",
-    strip_prefix = "rules_python-0.28.0",
-    urls = ["https://github.com/bazelbuild/rules_python/releases/download/0.28.0/rules_python-0.28.0.tar.gz"],
+    sha256 = "e85ae30de33625a63eca7fc40a94fea845e641888e52f32b6beea91e8b1b2793",
+    strip_prefix = "rules_python-0.27.1",
+    urls = ["https://github.com/bazelbuild/rules_python/releases/download/0.27.1/rules_python-0.27.1.tar.gz"],
 )
 
 load("@rules_python//python:repositories.bzl", "python_register_multi_toolchains")

--- a/third_party/dependencies.bzl
+++ b/third_party/dependencies.bzl
@@ -7,9 +7,9 @@ def dependencies():
     maybe(
         http_archive,
         name = "rules_python",
-        sha256 = "d70cd72a7a4880f0000a6346253414825c19cdd40a28289bdf67b8e6480edff8",
-        strip_prefix = "rules_python-0.28.0",
-        urls = ["https://github.com/bazelbuild/rules_python/releases/download/0.28.0/rules_python-0.28.0.tar.gz"],
+        sha256 = "e85ae30de33625a63eca7fc40a94fea845e641888e52f32b6beea91e8b1b2793",
+        strip_prefix = "rules_python-0.27.1",
+        urls = ["https://github.com/bazelbuild/rules_python/releases/download/0.27.1/rules_python-0.27.1.tar.gz"],
     )
 
     # Keep in sync with MODULE.bazel


### PR DESCRIPTION
We have no need for a newer version and 0.27.1 is the last version still supporting Bazel 5. Thus, we should use 0.27.1 as DWYU is as well still supporting Bazel 5.
While tests where green with 0.28.0, we don't want to risk problems in edge cases currently unknown to us.