### PR TITLE
No automated updates of main deps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -24,7 +24,8 @@
   "packageRules": [
     {
       "matchPackagePatterns": [
-        "rules_python"
+        "rules_python",
+        "rules_cc"
       ],
       "matchManagers": [
         "bazel",


### PR DESCRIPTION
We should define the minimum version of each required dependency and not use the latest greatest version due to the bzlmod dependency resolution scheme which uses the minimum version of all requested ones. Thus, relying on the latest versions without need restricts usage of DWYU by users.