### PR TITLE
 apply_fixes: Improve dependency discovery heuristic

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,11 +271,11 @@ Even if analysing the code works initially, it might break at any time if the or
 
 ### Aspect
 
-| Platform         | Constraints                                                                               |
-| ---------------- | ----------------------------------------------------------------------------------------- |
-| Operating system | Integration tests check \[Ubuntu 22.04, Macos 12, Windows 2022\].                         |
-| Python           | Minimum version is 3.8. Integration tests check \[3.8.x, 3.9.x, 3.10.x, 3.11.x, 3.12.x\]. |
-| Bazel            | Minimum version is 5.4.0. Integration tests check \[5.x, 6.x, 7.x, 8.0.0-pre.x\].         |
+| Platform         | Constraints                                                                       |
+| ---------------- | --------------------------------------------------------------------------------- |
+| Operating system | Integration tests check \[Ubuntu 22.04, Macos 12, Windows 2022\].                 |
+| Python           | Minimum version is 3.8. Integration tests check \[3.8, 3.9, 3.10, 3.11, 3.12\].   |
+| Bazel            | Minimum version is 5.4.0. Integration tests check \[5.x, 6.x, 7.x, 8.0.0-pre.x\]. |
 
 ### Applying fixes
 
@@ -319,7 +319,7 @@ Please be aware that the project is still in an early phase and until version 1.
 
 - The report files DWYU generates to facilitate running automatic fixes are considered an implementation detail.
   Changing their content is not considered a breaking change.
-- How to include DWYU in your project git commit might change at any time.
+- How to include DWYU in your project might change at any time.
 
 # Contributing
 

--- a/scripts/count_release_downloads.py
+++ b/scripts/count_release_downloads.py
@@ -11,7 +11,7 @@ statistics.
 import json
 import subprocess
 
-token = input("Please provide an access token with permissions 'contents:read': ")
+token = input("Please provide an access token with repository permission 'Read access to metadata': ")
 
 cmd = [
     "curl",

--- a/test/apply_fixes/missing_dependency/test_fail_on_ambiguous_dep_resolution.py
+++ b/test/apply_fixes/missing_dependency/test_fail_on_ambiguous_dep_resolution.py
@@ -24,7 +24,7 @@ class TestCase(TestCaseBase):
         )
 
         expected_error = [
-            "Found multiple targets which potentially can provide include 'ambiguous_lib/lib.h'",
+            "Found multiple targets providing invalid include path 'ambiguous_lib/lib.h'",
             "//ambiguous_lib:lib_a",
             "//ambiguous_lib:lib_b",
         ]

--- a/test/apply_fixes/missing_dependency/test_fail_on_unavailable_include.py
+++ b/test/apply_fixes/missing_dependency/test_fail_on_unavailable_include.py
@@ -23,7 +23,7 @@ class TestCase(TestCaseBase):
             check=True,
         )
 
-        expected_error = "Could not find a proper dependency for invalid include 'bar/private_bar.h'"
+        expected_error = "Could not find a proper dependency for invalid include path 'bar/private_bar.h'"
         if expected_error not in process.stderr:
             return self._make_unexpected_output_error(expected=expected_error, output=process.stderr)
         return Success()

--- a/test/apply_fixes/missing_dependency/test_suggest_missing_dep_based_on_fallback_logic_using_header_file_name.py
+++ b/test/apply_fixes/missing_dependency/test_suggest_missing_dep_based_on_fallback_logic_using_header_file_name.py
@@ -1,0 +1,17 @@
+from result import Result, Success
+from test_case import TestCaseBase
+
+
+class TestCase(TestCaseBase):
+    @property
+    def test_target(self) -> str:
+        return "//:use_manipulated_bar"
+
+    def execute_test_logic(self) -> Result:
+        self._create_reports()
+        self._run_automatic_fix(extra_args=["--fix-missing-deps"])
+
+        target_deps = self._get_target_attribute(target=self.test_target, attribute="deps")
+        if (expected := {"//:manipulated_bar_provider", "//libs:manipulated_bar"}) != target_deps:
+            return self._make_unexpected_deps_error(expected_deps=expected, actual_deps=target_deps)
+        return Success()

--- a/test/apply_fixes/missing_dependency/workspace/BUILD
+++ b/test/apply_fixes/missing_dependency/workspace/BUILD
@@ -45,9 +45,21 @@ cc_library(
     deps = [":libs_provider"],
 )
 
+cc_library(
+    name = "use_manipulated_bar",
+    hdrs = ["use_manipulated_bar.h"],
+    deps = [":manipulated_bar_provider"],
+)
+
 ##################
 # Helper Targets #
 ##################
+
+cc_library(
+    name = "manipulated_bar_provider",
+    srcs = ["dummy.h"],
+    deps = ["//libs:manipulated_bar"],
+)
 
 cc_library(
     name = "ambiguous_lib_provider",

--- a/test/apply_fixes/missing_dependency/workspace/libs/BUILD
+++ b/test/apply_fixes/missing_dependency/workspace/libs/BUILD
@@ -2,10 +2,19 @@ cc_library(
     name = "foo",
     hdrs = ["foo.h"],
     visibility = ["//visibility:public"],
+    deps = ["//other_lib"],
 )
 
 cc_library(
     name = "bar",
     hdrs = ["sub/bar.h"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "manipulated_bar",
+    hdrs = ["sub/bar.h"],
+    include_prefix = "new/path",
+    strip_include_prefix = ".",
     visibility = ["//visibility:public"],
 )

--- a/test/apply_fixes/missing_dependency/workspace/libs/foo.h
+++ b/test/apply_fixes/missing_dependency/workspace/libs/foo.h
@@ -1,3 +1,6 @@
+// Show that multiple files 'foo.h' in the dependency graph are no issue
+#include "other_lib/foo.h"
+
 int doFoo() {
-    return 1337;
+    return doOtherFoo() + 1337;
 }

--- a/test/apply_fixes/missing_dependency/workspace/other_lib/BUILD
+++ b/test/apply_fixes/missing_dependency/workspace/other_lib/BUILD
@@ -1,0 +1,7 @@
+# We use this library to prove that multiple header with the same name existing in the dependency is not a problem if
+# they are included with their full path
+cc_library(
+    name = "other_lib",
+    hdrs = ["foo.h"],
+    visibility = ["//visibility:public"],
+)

--- a/test/apply_fixes/missing_dependency/workspace/other_lib/foo.h
+++ b/test/apply_fixes/missing_dependency/workspace/other_lib/foo.h
@@ -1,0 +1,3 @@
+int doOtherFoo() {
+    return 1234;
+}

--- a/test/apply_fixes/missing_dependency/workspace/use_manipulated_bar.h
+++ b/test/apply_fixes/missing_dependency/workspace/use_manipulated_bar.h
@@ -1,0 +1,5 @@
+#include "new/path/sub/bar.h"
+
+int useBar() {
+    return doBar();
+}


### PR DESCRIPTION
Our old logic fails when multiple dependencies provide a header file with the same name at different paths.
The new logic is robust against this due to looking for the full include path. Looking at the file name is now only a fallback used to resolve cases where include path manipulation makes a simple include path match impossible.

Fixes: https://github.com/martis42/depend_on_what_you_use/issues/237
