### PR TITLE
Apply_fixes: Consistent CLI

### DIFF
--- a/src/apply_fixes/apply_fixes.py
+++ b/src/apply_fixes/apply_fixes.py
@@ -167,7 +167,10 @@ Maybe the tool used the wrong output directory, have a look at the apply_fixes C
         startup_args=shlex.split(args.bazel_startup_args) if args.bazel_startup_args else [],
     )
     buildozer_executor = BuildozerExecutor(
-        buildozer=buildozer, buildozer_args=args.buildozer_args, workspace=workspace, dry=args.dry_run
+        buildozer=buildozer,
+        buildozer_args=shlex.split(args.buildozer_args) if args.buildozer_args else [],
+        workspace=workspace,
+        dry=args.dry_run,
     )
     for report in reports:
         logging.debug(f"Processing report file '{report}'")

--- a/src/apply_fixes/main.py
+++ b/src/apply_fixes/main.py
@@ -27,6 +27,28 @@ The script expects 'bazel' to be available on PATH.
     """.strip(),
     )
     parser.add_argument(
+        "--fix-unused-deps",
+        action="store_true",
+        help="Automatically remove unused dependencies.",
+    )
+    parser.add_argument(
+        "--fix-deps-which-should-be-private",
+        action="store_true",
+        help="Automatically move 'deps' to 'implementation_deps'.",
+    )
+    parser.add_argument(
+        "--fix-missing-deps",
+        action="store_true",
+        help="""
+        Automatically search and add dependencies providing headers for which a direct dependency is missing. This is
+        based on a heuristic and thus is not guaranteed to work.""",
+    )
+    parser.add_argument(
+        "--fix-all",
+        action="store_true",
+        help="Perform all available automatic fixes.",
+    )
+    parser.add_argument(
         "--workspace",
         metavar="PATH",
         help="""
@@ -74,8 +96,8 @@ The script expects 'bazel' to be available on PATH.
         help="""
         The apply_fixes script uses 'bazel (c)query' to find missing dependencies. If this command requires further
         arguments to work properly in your workspace you can provide them here. Also look into '--use-cquery' if
-        you want to provide build configuration.
-        Arguments have ot be provided as one large string, e.g.: --bazel-args='--foo --tick=tock'.""",
+        you want to provide a build configuration.
+        Arguments have to be provided as continuous string, e.g.: --bazel-args='--foo --tick=tock'.""",
     )
     parser.add_argument(
         "--bazel-startup-args",
@@ -84,36 +106,7 @@ The script expects 'bazel' to be available on PATH.
         help="""
         The apply_fixes script uses 'bazel (c)query' to find missing dependencies. If this command requires further
         startup arguments (e.g. a custom output base) to work properly in your workspace you can provide them here.
-        Arguments have ot be provided as one large string, e.g.: --bazel-args='--foo --tick=tock'.""",
-    )
-    parser.add_argument(
-        "--fix-unused-deps",
-        action="store_true",
-        help="Automatically remove unused dependencies.",
-    )
-    parser.add_argument(
-        "--fix-deps-which-should-be-private",
-        action="store_true",
-        help="Automatically move 'deps' to 'implementation_deps'.",
-    )
-    parser.add_argument(
-        "--fix-missing-deps",
-        action="store_true",
-        help="""
-        Automatically search and add dependencies providing headers for which a direct dependency is missing. This is
-        based on a heuristic and thus is not guaranteed to work.""",
-    )
-    parser.add_argument(
-        "--fix-all",
-        action="store_true",
-        help="Perform all available automatic fixes.",
-    )
-    parser.add_argument(
-        "--buildozer",
-        metavar="PATH",
-        help="""
-        buildozer binary which shall be used by this script. If none is provided, it is expected to find buildozer on
-        PATH.""",
+        Arguments have to be provided as continuous string, e.g.: -bazel-startup-args='--foo --tick=tock'.""",
     )
     parser.add_argument(
         "--dry-run",
@@ -124,6 +117,13 @@ The script expects 'bazel' to be available on PATH.
         "--verbose",
         action="store_true",
         help="Announce intermediate steps.",
+    )
+    parser.add_argument(
+        "--buildozer",
+        metavar="PATH",
+        help="""
+        buildozer binary which shall be used by this script. If none is provided, it is expected to find buildozer on
+        PATH.""",
     )
     parser.add_argument(
         "--buildozer-args",

--- a/src/apply_fixes/main.py
+++ b/src/apply_fixes/main.py
@@ -1,6 +1,6 @@
 import logging
 import sys
-from argparse import REMAINDER, ArgumentParser, Namespace, RawDescriptionHelpFormatter
+from argparse import ArgumentParser, Namespace, RawDescriptionHelpFormatter
 
 from src.apply_fixes.apply_fixes import main
 
@@ -127,8 +127,11 @@ The script expects 'bazel' to be available on PATH.
     )
     parser.add_argument(
         "--buildozer-args",
-        nargs=REMAINDER,
-        help="Forward arguments to buildozer. Has to be the last option in the command line.",
+        type=str,
+        metavar="STRING",
+        help="""
+        Forward arguments to buildozer.
+        Arguments have to be provided as continuous string, e.g.: --buildozer-args='-foo -tick=tock'.""",
     )
 
     args = parser.parse_args()

--- a/test/apply_fixes/tool_cli/test_forward_args_to_buildozer.py
+++ b/test/apply_fixes/tool_cli/test_forward_args_to_buildozer.py
@@ -9,8 +9,9 @@ class TestCase(TestCaseBase):
 
     def execute_test_logic(self) -> Result:
         self._create_reports()
-        # Make buildozer a noop by writing changes to output instead of to the BUILD file
-        self._run_automatic_fix(extra_args=["--fix-unused", "--buildozer-args", "-stdout"])
+        # Make buildozer a noop by writing changes to output instead of to the BUILD file. We don't need to limit the
+        # processes for the core test logic. We simply do this to test the forwarding of multiple arguments.
+        self._run_automatic_fix(extra_args=["--fix-unused", "--buildozer-args='-stdout' -P=2"])
 
         target_deps = self._get_target_attribute(target=self.test_target, attribute="deps")
         if (expected := {"//:lib"}) != target_deps:


### PR DESCRIPTION
This makes the buildozer-args option consistent to the bazel-args. Also it removes the restriction of `--buildozer-args` having to be the last argument.

Furthermore, we:
- Fix typos
- Reorder options. Subjectively this order is more natural from most important to least important and somewhat consistent in itself.