### PR TITLE
apply_fixes: More flexible bazel-info usage

### DIFF
--- a/src/apply_fixes/main.py
+++ b/src/apply_fixes/main.py
@@ -60,16 +60,15 @@ The script expects 'bazel' to be available on PATH.
     )
     parser.add_argument(
         "--use-bazel-info",
-        const="fastbuild",
-        choices=["dbg", "fastbuild", "opt"],
-        nargs="?",
+        action="store_true",
         help="""
         Don't follow the convenience symlinks to reach the Bazel output directory containing the DWYU reports. Instead,
         use 'bazel info' to deduce the output directory.
-        This option accepts an optional argument specifying the compilation mode which was used to generate the DWYU
-        report files.
         Using this option is recommended if the convenience symlinks do not exist, don't follow the default
-        naming scheme or do not point to the Bazel output directory containing the DWYU reports.""",
+        naming scheme or do not point to the Bazel output directory containing the DWYU reports.
+        Please be aware that that compilation mode used to invoke 'bazel info' has to match the compilation mode used
+        to execute DWYU. To configure which arguments are passed to bazel look at options '--bazel-args' and
+         '--bazel-startup-args'.""",
     )
     parser.add_argument(
         "--search-path",

--- a/test/apply_fixes/tool_cli/test_forward_args_to_buildozer.py
+++ b/test/apply_fixes/tool_cli/test_forward_args_to_buildozer.py
@@ -11,7 +11,7 @@ class TestCase(TestCaseBase):
         self._create_reports()
         # Make buildozer a noop by writing changes to output instead of to the BUILD file. We don't need to limit the
         # processes for the core test logic. We simply do this to test the forwarding of multiple arguments.
-        self._run_automatic_fix(extra_args=["--fix-unused", "--buildozer-args='-stdout' -P=2"])
+        self._run_automatic_fix(extra_args=["--fix-unused", "--buildozer-arg", "-stdout -P=2"])
 
         target_deps = self._get_target_attribute(target=self.test_target, attribute="deps")
         if (expected := {"//:lib"}) != target_deps:

--- a/test/apply_fixes/tool_cli/test_utilize_bazel_info_with_custom_compilation_mode.py
+++ b/test/apply_fixes/tool_cli/test_utilize_bazel_info_with_custom_compilation_mode.py
@@ -9,7 +9,11 @@ class TestCase(TestCaseBase):
 
     def execute_test_logic(self) -> Result:
         self._create_reports(extra_args=["--noexperimental_convenience_symlinks", "--compilation_mode=opt"])
-        self._run_automatic_fix(extra_args=["--fix-unused", "--use-bazel-info=opt"])
+        # The remote cache arg has no meaning for the test behavior. It is only used to check that parsing multiple
+        # arguments from one string works without error.
+        self._run_automatic_fix(
+            extra_args=["--fix-unused", "--use-bazel-info", "--bazel-args", "--remote_cache= -c opt"]
+        )
 
         target_deps = self._get_target_attribute(target=self.test_target, attribute="deps")
         if (expected := set()) != target_deps:  # type: ignore[var-annotated]


### PR DESCRIPTION
In some workspaces users have to provide custom arguments to use 'bazel info', which is now possible.

Resolves: https://github.com/martis42/depend_on_what_you_use/pull/246