### PR TITLE
Fix target_mapping not working with implementation_deps

### DIFF
--- a/src/aspect/dwyu.bzl
+++ b/src/aspect/dwyu.bzl
@@ -135,14 +135,14 @@ def _exchange_cc_info(deps, mapping):
 def _preprocess_deps(ctx):
     """
     Normally this function does nothing and simply stores dependencies and their CcInfo providers in a specific format.
-    If the user chooses to use the target mapping feature, we exchange here the CcInf provider for some targets with a
+    If the user chooses to use the target mapping feature, we exchange here the CcInfo provider for some targets with a
     different one.
     """
     target_impl_deps = []
     if ctx.attr._target_mapping:
         target_deps = _exchange_cc_info(deps = ctx.rule.attr.deps, mapping = ctx.attr._target_mapping)
         if hasattr(ctx.rule.attr, "implementation_deps"):
-            pass
+            target_impl_deps = _exchange_cc_info(deps = ctx.rule.attr.implementation_deps, mapping = ctx.attr._target_mapping)
     else:
         target_deps = [struct(label = dep.label, cc_info = dep[CcInfo]) for dep in ctx.rule.attr.deps]
         if hasattr(ctx.rule.attr, "implementation_deps"):

--- a/test/aspect/target_mapping/BUILD
+++ b/test/aspect/target_mapping/BUILD
@@ -9,3 +9,9 @@ cc_binary(
     srcs = ["use_lib_c.cpp"],
     deps = ["//target_mapping/libs:a"],
 )
+
+cc_library(
+    name = "use_lib_b_privately",
+    srcs = ["use_lib_b.cpp"],
+    implementation_deps = ["//target_mapping/libs:a"],
+)

--- a/test/aspect/target_mapping/test_use_b_via_impl_deps_with_specific_mapping.py
+++ b/test/aspect/target_mapping/test_use_b_via_impl_deps_with_specific_mapping.py
@@ -1,0 +1,14 @@
+from result import ExpectedResult, Result
+from test_case import TestCaseBase
+
+
+class TestCase(TestCaseBase):
+    def execute_test_logic(self) -> Result:
+        expected = ExpectedResult(success=True)
+        actual = self._run_dwyu(
+            target="//target_mapping:use_lib_b_privately",
+            aspect="//target_mapping:aspect.bzl%map_specific_deps",
+            extra_args=["--experimental_cc_implementation_deps"],
+        )
+
+        return self._check_result(actual=actual, expected=expected)


### PR DESCRIPTION
A code path required for implementation_deps was missing, which is now fixed.

Resolves https://github.com/martis42/depend_on_what_you_use/issues/253