### PR TITLE
apply_fixes can parse report files from a DWYU execution log

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,10 @@ You can see the full command line interface and more information about the scrip
 If the `apply_fixes` tool is not able to discover the report files, this can be caused by the `bazel-bin` convenience symlink at the workspace root not existing or not pointing to the output directory which was used by to generate the report files.
 The tool offers options to control how the output directory is discovered.
 
+Discovering the DWYU report files automatically can take a large amount of time if the `bazel-bin` directory is too large.
+In such cases you can pipe the command line output of executing the DWYU aspect into a file and forward this file to the apply_fixes script via the `--dwyu-log-file` option.
+The apply_fixes script will then deduce the DWYU report file locations without crawling though thw whole `bazel-bin` directory.
+
 Unfortunately, the tool cannot promise perfect results due to various constraints:
 
 - If alias targets are involved, this cannot be processed properly.

--- a/src/analyze_includes/main.py
+++ b/src/analyze_includes/main.py
@@ -99,6 +99,7 @@ def main(args: Namespace) -> int:
         system_under_inspection=system_under_inspection,
         ensure_private_deps=args.implementation_deps_available,
     )
+    result.report = args.report
 
     args.report.parent.mkdir(parents=True, exist_ok=True)
     with args.report.open(mode="w", encoding="utf-8") as report:

--- a/src/analyze_includes/result.py
+++ b/src/analyze_includes/result.py
@@ -6,18 +6,22 @@ from json import dumps
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from src.analyze_includes.parse_source import Include
 
 
 @dataclass
 class Result:
     target: str
+    report: Path | None = None
+    use_impl_deps: bool = False
+
     public_includes_without_dep: list[Include] = field(default_factory=list)
     private_includes_without_dep: list[Include] = field(default_factory=list)
     unused_deps: list[str] = field(default_factory=list)
     unused_impl_deps: list[str] = field(default_factory=list)
     deps_which_should_be_private: list[str] = field(default_factory=list)
-    use_impl_deps: bool = False
 
     def is_ok(self) -> bool:
         return (
@@ -47,6 +51,9 @@ class Result:
         if self.deps_which_should_be_private:
             msg += "\nPublic dependencies which are used only in private code:\n"
             msg += "\n".join(f"  Dependency='{dep}'" for dep in self.deps_which_should_be_private)
+
+        msg += f"\n\nDWYU Report: {self.report}"
+
         return self._framed_msg(msg)
 
     def to_json(self) -> str:

--- a/src/apply_fixes/BUILD
+++ b/src/apply_fixes/BUILD
@@ -6,6 +6,7 @@ py_library(
         "apply_fixes.py",
         "bazel_query.py",
         "buildozer_executor.py",
+        "get_dwyu_reports.py",
         "search_missing_deps.py",
         "summary.py",
         "utils.py",

--- a/src/apply_fixes/get_dwyu_reports.py
+++ b/src/apply_fixes/get_dwyu_reports.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import logging
+import sys
+from os import walk
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from src.apply_fixes.utils import args_string_to_list, execute_and_capture
+
+if TYPE_CHECKING:
+    import argparse
+
+
+def gather_reports(main_args: argparse.Namespace, search_path: Path) -> list[Path]:
+    if main_args.dwyu_log_file:
+        from platform import system
+
+        bin_dir = "\\bin\\" if system() == "Windows" else "/bin/"
+        return [search_path / log.split(bin_dir, 1)[1] for log in parse_dwyu_execution_log(main_args.dwyu_log_file)]
+
+    reports = []
+    # We explicitly use os.walk() as it has better performance than Path.glob() in large and deeply nested file trees.
+    for root, _, files in walk(search_path):
+        for file in files:
+            if file.endswith("_dwyu_report.json"):
+                reports.append(Path(root) / file)  # noqa: PERF401
+    return reports
+
+
+def parse_dwyu_execution_log(log_file: Path) -> list[str]:
+    dwyu_report_anchor = "DWYU Report: "
+    with log_file.open() as log:
+        return [
+            line.strip().split(dwyu_report_anchor)[1] for line in log.readlines() if line.startswith(dwyu_report_anchor)
+        ]
+
+
+def get_reports_search_dir(main_args: argparse.Namespace, workspace_root: Path) -> Path:
+    """
+    Unless an alternative method is selected, follow the convenience symlinks at the workspace root to discover the
+    DWYU report files.
+    """
+    if main_args.search_path:
+        return Path(main_args.search_path)
+
+    if main_args.use_bazel_info:
+        process = execute_and_capture(
+            cmd=[
+                "bazel",
+                *args_string_to_list(main_args.bazel_startup_args),
+                "info",
+                *args_string_to_list(main_args.bazel_args),
+                "bazel-bin",
+            ],
+            cwd=workspace_root,
+        )
+        return Path(process.stdout.strip())
+
+    bazel_bin_link = workspace_root / "bazel-bin"
+    if not bazel_bin_link.is_dir():
+        logging.fatal(f"ERROR: convenience symlink '{bazel_bin_link}' does not exist.")
+        sys.exit(1)
+    return bazel_bin_link.resolve()

--- a/src/apply_fixes/main.py
+++ b/src/apply_fixes/main.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 from argparse import ArgumentParser, Namespace, RawDescriptionHelpFormatter
+from pathlib import Path
 
 from src.apply_fixes.apply_fixes import main
 
@@ -80,6 +81,20 @@ The script expects 'bazel' to be available on PATH.
         of the Bazel output directories.""",
     )
     parser.add_argument(
+        "--dwyu-log-file",
+        metavar="PATH",
+        type=Path,
+        help="""
+        If discovering the DWYU report files in the bazel-bin is not feasible, one can instead pipe the command line
+        output of executing the DWYU aspect into a log file and tell this script to extract the DWYU report paths from
+        this execution log. This can be helpful when your workspace is so large, that crawling the corresponding
+        'bazel-bin' directory is too slow for a satisfactory user experience. This script still has to be able to
+        discover the location of the 'bazel-bin' directory. Meaning, the 'bazel-bin' convenience symlink at the
+        workspace root should exists or if it is not available one of the following options should be used:
+        ['--use-bazel-info', '--search-path']. Please note when using '--search-path' you have to point exactly to the
+        'bazel-bin' directory and can't point so sub directories.""",
+    )
+    parser.add_argument(
         "--use-cquery",
         action="store_true",
         help="""
@@ -138,6 +153,10 @@ The script expects 'bazel' to be available on PATH.
     has_explicit_fix_option = any((args.fix_unused_deps, args.fix_deps_which_should_be_private, args.fix_missing_deps))
     if not has_explicit_fix_option and not args.fix_all:
         logging.fatal("Please choose at least one of the 'fix-..' options")
+        sys.exit(1)
+
+    if args.use_bazel_info and args.search_path:
+        logging.fatal("Please choose only one options controlling the 'bazel-bin' directory discovery.")
         sys.exit(1)
 
     return args

--- a/src/apply_fixes/test/BUILD
+++ b/src/apply_fixes/test/BUILD
@@ -13,6 +13,12 @@ py_test(
 )
 
 py_test(
+    name = "get_dwyu_reports_test",
+    srcs = ["get_dwyu_reports_test.py"],
+    deps = ["//src/apply_fixes:lib"],
+)
+
+py_test(
     name = "search_missing_deps",
     srcs = ["search_missing_deps.py"],
     deps = ["//src/apply_fixes:lib"],
@@ -21,5 +27,11 @@ py_test(
 py_test(
     name = "summary_test",
     srcs = ["summary_test.py"],
+    deps = ["//src/apply_fixes:lib"],
+)
+
+py_test(
+    name = "utils_test",
+    srcs = ["utils_test.py"],
     deps = ["//src/apply_fixes:lib"],
 )

--- a/src/apply_fixes/test/get_dwyu_reports_test.py
+++ b/src/apply_fixes/test/get_dwyu_reports_test.py
@@ -1,0 +1,35 @@
+import unittest
+from pathlib import Path
+
+from src.apply_fixes.get_dwyu_reports import parse_dwyu_execution_log
+
+
+class TestParseDwyuExecutionLog(unittest.TestCase):
+    def test_parse_dwyu_execution_log(self) -> None:
+        test_log = Path("test_log.txt")
+        with test_log.open(mode="wt") as fp:
+            fp.write(
+                """
+Some unrelated stuff
+DWYU Report: bazel-out/opt/bin/some/target_dwyu_report.json
+ERROR: Unrelated error
+DWYU Report: bazel-out/opt/bin/root_target_dwyu_report.json
+""".strip()
+            )
+
+        logs = parse_dwyu_execution_log(test_log)
+        self.assertEqual(
+            logs, ["bazel-out/opt/bin/some/target_dwyu_report.json", "bazel-out/opt/bin/root_target_dwyu_report.json"]
+        )
+
+    def test_parse_dwyu_execution_log_empty(self) -> None:
+        test_log = Path("test_log.txt")
+        with test_log.open(mode="wt") as fp:
+            fp.write("")
+
+        logs = parse_dwyu_execution_log(test_log)
+        self.assertEqual(logs, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/apply_fixes/test/utils_test.py
+++ b/src/apply_fixes/test/utils_test.py
@@ -1,0 +1,19 @@
+import unittest
+
+from src.apply_fixes.utils import args_string_to_list
+
+
+class TestArgsStringToList(unittest.TestCase):
+    def test_no_args(self) -> None:
+        self.assertEqual(args_string_to_list(None), [])
+        self.assertEqual(args_string_to_list(""), [])
+
+    def test_single_arg(self) -> None:
+        self.assertEqual(args_string_to_list("foo"), ["foo"])
+
+    def test_multiple_args(self) -> None:
+        self.assertEqual(args_string_to_list("--foo --bar=42 baz 1337"), ["--foo", "--bar=42", "baz", "1337"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/apply_fixes/utils.py
+++ b/src/apply_fixes/utils.py
@@ -9,6 +9,10 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
+def args_string_to_list(args: str | None) -> list[str]:
+    return shlex.split(args) if args else []
+
+
 def execute_and_capture(cmd: list[str], cwd: Path, check: bool = True) -> subprocess.CompletedProcess:
     logging.debug(f"Executing command: {shlex.join(cmd)}")
     return subprocess.run(cmd, cwd=cwd, check=check, capture_output=True, text=True)

--- a/test/apply_fixes/tool_cli/test_get_dwyu_reports_from_execution_log.py
+++ b/test/apply_fixes/tool_cli/test_get_dwyu_reports_from_execution_log.py
@@ -1,0 +1,26 @@
+from result import Result, Success
+from test_case import TestCaseBase
+
+
+class TestCase(TestCaseBase):
+    @property
+    def test_target(self) -> str:
+        return "//..."
+
+    def execute_test_logic(self) -> Result:
+        dwyu_cmd = self._make_create_reports_cmd(extra_args=["--keep_going"])
+        dwyu_process = self._run_and_capture_cmd(dwyu_cmd, check=False)
+
+        log_file = self._workspace / "dwyu_log.log"
+        with log_file.open(mode="wt") as log:
+            log.write(dwyu_process.stdout)
+
+        self._run_automatic_fix(extra_args=["--fix-unused", f"--dwyu-log-file={log_file}"])
+
+        if len(deps := self._get_target_attribute(target="//:binary", attribute="deps")) > 0:
+            return self._make_unexpected_deps_error(expected_deps=[], actual_deps=deps)
+        if len(deps := self._get_target_attribute(target="//:another_binary", attribute="deps")) > 0:
+            return self._make_unexpected_deps_error(expected_deps=[], actual_deps=deps)
+        if len(deps := self._get_target_attribute(target="//sub/foo:foo", attribute="deps")) > 0:
+            return self._make_unexpected_deps_error(expected_deps=[], actual_deps=deps)
+        return Success()

--- a/test/apply_fixes/tool_cli/workspace/BUILD
+++ b/test/apply_fixes/tool_cli/workspace/BUILD
@@ -1,10 +1,19 @@
 cc_library(
     name = "lib",
     hdrs = ["lib.h"],
+    visibility = [":__subpackages__"],
 )
 
 cc_binary(
     name = "binary",
+    srcs = ["binary.cpp"],
+    deps = [
+        ":lib",  # unused
+    ],
+)
+
+cc_binary(
+    name = "another_binary",
     srcs = ["binary.cpp"],
     deps = [
         ":lib",  # unused

--- a/test/apply_fixes/tool_cli/workspace/sub/foo/BUILD
+++ b/test/apply_fixes/tool_cli/workspace/sub/foo/BUILD
@@ -1,0 +1,7 @@
+cc_library(
+    name = "foo",
+    hdrs = ["foo.h"],
+    deps = [
+        "//:lib",  # unused
+    ],
+)


### PR DESCRIPTION
For large workspaces discovering the DWYU report files by crawling the bazel-out directory can be quite slow due to an enormous amount of files and directories being present.
To work around this, we enable the apply_fixes script to parse a log file containing the command line output of executing the DWYU aspect. This execution log is then parsed and the DWYU report paths deduced.