### PR TITLE
Update Ubuntu in BCR tests

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,7 +1,7 @@
 bcr_test_module:
   module_path: "examples"
   matrix:
-    platform: [ "macos", "ubuntu2004", "windows" ]
+    platform: [ "macos", "ubuntu2204", "windows" ]
     # DWYU supports Bazel 5.4.0, but only via WORKSPACE
     bazel: [ "6.x", "7.x", "rolling" ]
   tasks:


### PR DESCRIPTION
20.04 is quite old by now and our CI uses also 22.04