### PR TITLE
Do not execute CI checks on drafts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ on: [ pull_request ]
 
 jobs:
   pre-commit:
+    if: ${{ (github.event.pull_request.draft == false) || contains(github.event.comment.body, '/check') }}
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Often we use a draft simply to store intermediate work in an easy to look at format. However, on demand one can run the CI via putting `/check` in a comment.