### PR TITLE
Use param files to invoke process_target.py

### DIFF
--- a/src/aspect/dwyu.bzl
+++ b/src/aspect/dwyu.bzl
@@ -45,6 +45,9 @@ def _process_target(ctx, target, defines, output_path, is_target_under_inspectio
     if verbose:
         args.add("--verbose")
 
+    args.set_param_file_format("multiline")
+    args.use_param_file("--param_file=%s", use_always = True)
+
     ctx.actions.run(
         inputs = header_files,
         executable = ctx.executable._process_target,

--- a/src/aspect/process_target.py
+++ b/src/aspect/process_target.py
@@ -38,7 +38,11 @@ def cli() -> Namespace:
     )
     parser.add_argument("--verbose", action="store_true", help="Print debugging output")
 
-    args = parser.parse_args()
+    if len(sys.argv) == 2 and sys.argv[1].startswith("--param_file="):
+        param_file = Path(sys.argv[1][len("--param_file=") :])
+        args = parser.parse_args(param_file.read_text().splitlines())
+    else:
+        args = parser.parse_args()
     if args.verbose:
         logging.getLogger().setLevel(logging.DEBUG)
 


### PR DESCRIPTION
Without a param file invocations fail with "Argument list too long" when run on larger projects.