### PR TITLE
fix(aspect): Allow multiple dependencies providing the same header

### DIFF
--- a/src/analyze_includes/evaluate_includes.py
+++ b/src/analyze_includes/evaluate_includes.py
@@ -74,7 +74,6 @@ def _check_for_invalid_includes(
             ):
                 legal_include = True
                 dep.usage.update(usage)
-                break
         if not legal_include:
             # Might be a file from the target under inspection
             legal_include = does_include_match_available_files(

--- a/src/analyze_includes/test/evaluate_includes_test.py
+++ b/src/analyze_includes/test/evaluate_includes_test.py
@@ -335,6 +335,25 @@ class TestEvaluateIncludes(unittest.TestCase):
 
         self.assertTrue(result.is_ok())
 
+    def test_include_matching_multiple_dependencies(self) -> None:
+        result = evaluate_includes(
+            public_includes=[Include(file=Path("file1"), include="bar.h")],
+            private_includes=[],
+            system_under_inspection=SystemUnderInspection(
+                target_under_inspection=CcTarget(name="foo", header_files=[]),
+                deps=[
+                    CcTarget(name="fizz", header_files=["bar.h"]),
+                    CcTarget(name="buzz", header_files=["bar.h"]),
+                ],
+                impl_deps=[],
+                include_paths=[""],
+                defines=[],
+            ),
+            ensure_private_deps=False,
+        )
+
+        self.assertTrue(result.is_ok())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/aspect/multiple_deps_for_one_header/BUILD
+++ b/test/aspect/multiple_deps_for_one_header/BUILD
@@ -1,0 +1,18 @@
+cc_library(
+    name = "foo",
+    hdrs = ["foo.h"],
+    deps = [
+        ":bar_a",
+        ":bar_b",
+    ],
+)
+
+cc_library(
+    name = "bar_a",
+    hdrs = ["bar.h"],
+)
+
+cc_library(
+    name = "bar_b",
+    hdrs = ["bar.h"],
+)

--- a/test/aspect/multiple_deps_for_one_header/foo.h
+++ b/test/aspect/multiple_deps_for_one_header/foo.h
@@ -1,0 +1,1 @@
+#include "multiple_deps_for_one_header/bar.h"

--- a/test/aspect/multiple_deps_for_one_header/test_multiple_deps_for_one_header.py
+++ b/test/aspect/multiple_deps_for_one_header/test_multiple_deps_for_one_header.py
@@ -1,0 +1,14 @@
+from result import ExpectedResult, Result
+from test_case import TestCaseBase
+
+
+class TestCase(TestCaseBase):
+    def execute_test_logic(self) -> Result:
+        """
+        Multiple dependencies providing the same header can be considered an antipattern. Still, with respect to the
+        DWYU principles it is not wrong. Such cases should not cause a DWYU error.
+        """
+        expected = ExpectedResult(success=True)
+        actual = self._run_dwyu(target="//multiple_deps_for_one_header:foo", aspect=self.default_aspect)
+
+        return self._check_result(actual=actual, expected=expected)


### PR DESCRIPTION
Such cases shall not cause the DWYU dependency to report an unused dependency.

Fixes https://github.com/martis42/depend_on_what_you_use/issues/289