### PR TITLE
refactor(aspect): Only use a param file if required

### DIFF
--- a/src/aspect/dwyu.bzl
+++ b/src/aspect/dwyu.bzl
@@ -71,7 +71,7 @@ def _process_target(ctx, target, defines, output_path, is_target_under_inspectio
         args.add("--verbose")
 
     args.set_param_file_format("multiline")
-    args.use_param_file("--param_file=%s", use_always = True)
+    args.use_param_file("--param_file=%s")
 
     ctx.actions.run(
         inputs = header_files,

--- a/src/aspect/process_target.py
+++ b/src/aspect/process_target.py
@@ -56,6 +56,7 @@ def main(args: Namespace) -> int:
     logging.debug(f"Includes             '{args.includes}'")
     logging.debug(f"Quote includes       '{args.quote_includes}'")
     logging.debug(f"System includes      '{args.system_includes}'")
+    logging.debug(f"Defines              '{args.defines}'")
 
     output = {"target": args.target, "header_files": args.header_files}
     if args.includes is not None:

--- a/test/aspect/command_length_limit/BUILD
+++ b/test/aspect/command_length_limit/BUILD
@@ -1,0 +1,17 @@
+"""
+Show that the DWYU aspect can handle cases where some attributes of the target under inspection are so large that the
+resulting command invocations are larger than the system's command length limits.
+
+We only test the command line length limit for the target processing step. A test for the analysis step would have an
+enormous runtime. Such a scenario is unlikely in a real project and thus we skip it for now.
+"""
+
+load(":make_large_arg.bzl", "make_large_defines")
+
+CHARACTERS_IN_COMMAND = 5000000
+
+cc_library(
+    name = "many_defines",
+    hdrs = ["foo.h"],
+    local_defines = make_large_defines(CHARACTERS_IN_COMMAND),
+)

--- a/test/aspect/command_length_limit/make_large_arg.bzl
+++ b/test/aspect/command_length_limit/make_large_arg.bzl
@@ -1,0 +1,5 @@
+# buildifier: disable=unnamed-macro
+def make_large_defines(minimum_characters):
+    fake_define = "_0123456789_ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz"
+    steps = int(minimum_characters / len(fake_define)) + 1
+    return ["{i}{define}".format(i = i, define = fake_define) for i in range(steps)]

--- a/test/aspect/command_length_limit/test_command_length_limit.py
+++ b/test/aspect/command_length_limit/test_command_length_limit.py
@@ -1,0 +1,10 @@
+from result import ExpectedResult, Result
+from test_case import TestCaseBase
+
+
+class TestCase(TestCaseBase):
+    def execute_test_logic(self) -> Result:
+        expected = ExpectedResult(success=True)
+        actual = self._run_dwyu(target="//command_length_limit:many_defines", aspect=self.default_aspect)
+
+        return self._check_result(actual=actual, expected=expected)


### PR DESCRIPTION
Bazel can detect whether a param file is required. We ensure this works as desired by adding a test.
