### PR TITLE
build: Drop Bazel 5.x support

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -2,8 +2,7 @@ bcr_test_module:
   module_path: "examples"
   matrix:
     platform: [ "macos", "ubuntu2204", "windows" ]
-    # DWYU supports Bazel 5.4.0, but only via WORKSPACE
-    bazel: [ "6.x", "7.x", "rolling" ]
+    bazel: [ "6.x", "7.x", "8.x", "rolling" ]
   tasks:
     verify_examples:
       name: "Verify examples"

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,8 +1,8 @@
 module(
     name = "depend_on_what_you_use",
     version = "0.0.0",
-    # Keep in sync with setup_step_2.bzl
-    bazel_compatibility = [">=5.4.0"],
+    # Keep in sync with setup_step_2.bzl, .bcr/presubmit.yml and the README.md
+    bazel_compatibility = [">=6.0.0"],
 )
 
 bazel_dep(name = "rules_cc", version = "0.0.8")

--- a/README.md
+++ b/README.md
@@ -195,17 +195,17 @@ While DWYU cannot generally know the values of all those compiler defined macros
 
 ### Aspect
 
-| Platform         | Constraints                                                                     |
-| ---------------- | ------------------------------------------------------------------------------- |
-| Operating system | Integration tests check [Ubuntu 22.04, Macos 12, Windows 2022].                 |
-| Python           | Minimum version is 3.8. Integration tests check [3.8, 3.9, 3.10, 3.11, 3.12].   |
-| Bazel            | Minimum version is 5.4.0. Integration tests check [5.x, 6.x, 7.x, 8.0.0-pre.x]. |
+| Platform         | Constraints                                                                   |
+| ---------------- | ----------------------------------------------------------------------------- |
+| Operating system | Integration tests check [Ubuntu 24.04, Macos 15, Windows 2022].               |
+| Python           | Minimum version is 3.8. Integration tests check [3.8, 3.9, 3.10, 3.11, 3.12]. |
+| Bazel            | Minimum version is 6.0.0. Integration tests check [6.x, 7.x, 8.x, rolling].   |
 
 ### Applying fixes
 
 | Platform         | Constraints                                                     |
 | ---------------- | --------------------------------------------------------------- |
-| Operating system | Integration tests check [Ubuntu 22.04, Macos 12, Windows 2022]. |
+| Operating system | Integration tests check [Ubuntu 24.04, Macos 15, Windows 2022]. |
 | Python           | Minimum version is 3.8. Integration tests check 3.8.            |
 | Bazel            | No known constraint. Integration tests check 7.0.0.             |
 | Buildozer        | No known constraint. Integration tests check 6.4.0.             |

--- a/setup_step_2.bzl
+++ b/setup_step_2.bzl
@@ -8,8 +8,8 @@ def setup_step_2():
 
     # Fail early for incompatible Bazel versions instead of printing obscure errors from within our implementation
     versions.check(
-        # Keep in sync with MODULE.bazel
-        minimum_bazel_version = "5.4.0",
+        # Keep in sync with MODULE.bazel, .bcr/presubmit.yml and the README.md
+        minimum_bazel_version = "6.0.0",
     )
 
     py_repositories()

--- a/test/aspect/execute_tests.py
+++ b/test/aspect/execute_tests.py
@@ -14,17 +14,19 @@ logging.basicConfig(format="%(message)s", level=logging.INFO)
 # manually define pairs which make sure each Bazel and Python version we care about is used at least once.
 # For versions using the legacy WORKSPACE setup we have to specify the patch version for Python
 TESTED_VERSIONS = [
-    TestedVersions(bazel="5.4.1", python="3.8.18"),
-    TestedVersions(bazel="6.5.0", python="3.9.18"),
-    TestedVersions(bazel="7.0.0", python="3.10"),
-    TestedVersions(bazel="7.3.1", python="3.11", is_default=True),
+    TestedVersions(bazel="6.0.0", python="3.8.18"),
+    TestedVersions(bazel="6.5.0", python="3.8"),
+    TestedVersions(bazel="7.0.0", python="3.9"),
+    TestedVersions(bazel="7.4.1", python="3.10"),
+    TestedVersions(bazel="8.0.0", python="3.11", is_default=True),
     TestedVersions(bazel="rolling", python="3.12"),
 ]
 
 VERSION_SPECIFIC_ARGS = {
-    # We support Bazel's modern dependency management system, but it works only as desired with a recent Bazel version
-    "--experimental_enable_bzlmod=false": CompatibleVersions(before="6.0.0"),
+    # We test Bazel 6 once with bzlmod and once with legacy WORKSPACE setup. Newer Bazel versions are only tested
+    # with bzlmod. bzlmod does not work for us before Bazel 6.2.
     "--enable_bzlmod=false": CompatibleVersions(minimum="6.0.0", before="6.2.0"),
+    "--enable_bzlmod=true": CompatibleVersions(minimum="6.2.0", before="7.0.0"),
     # Incompatible changes
     "--incompatible_legacy_local_fallback=false": CompatibleVersions(minimum="5.0.0"),  # false is the forward path
     "--incompatible_enforce_config_setting_visibility": CompatibleVersions(minimum="5.0.0"),


### PR DESCRIPTION
With the release of Bazel 8, Bazel 5 is deprecated. This step unblocks updates of our dependencies to recent versions.

BREAKING CHANGE: Bazel 6.0.0 is now the minimum version for DWYU.