### PR TITLE
feat: Support --noexperimental_python_import_all_repositories

### DIFF
--- a/src/analyze_includes/BUILD
+++ b/src/analyze_includes/BUILD
@@ -18,6 +18,8 @@ py_library(
 py_binary(
     name = "analyze_includes",
     srcs = ["main.py"],
+    # Compatibility to --noexperimental_python_import_all_repositories
+    imports = ["../.."],
     legacy_create_init = False,
     main = "main.py",
     visibility = ["//visibility:public"],

--- a/src/apply_fixes/BUILD
+++ b/src/apply_fixes/BUILD
@@ -18,6 +18,8 @@ py_library(
 py_binary(
     name = "main",
     srcs = ["main.py"],
+    # Compatibility to --noexperimental_python_import_all_repositories
+    imports = ["../.."],
     visibility = ["//:__pkg__"],
     deps = [":lib"],
 )

--- a/test/apply_fixes/execution_logic.py
+++ b/test/apply_fixes/execution_logic.py
@@ -40,6 +40,9 @@ common --nolegacy_external_runfiles
 
 # Useless as the workspace are thrown away after each creation
 common --lockfile_mode=off
+
+# Some users require this setting to mitigate issues due to a large PYTHONPATH created by rules_python
+build --noexperimental_python_import_all_repositories
 """
 
 BAZEL_VERSION = "7.4.1"

--- a/test/aspect/execute_tests.py
+++ b/test/aspect/execute_tests.py
@@ -33,7 +33,9 @@ VERSION_SPECIFIC_ARGS = {
     # with bzlmod. bzlmod does not work for us before Bazel 6.2.
     "--enable_bzlmod=false": CompatibleVersions(minimum="6.0.0", before="6.2.0"),
     "--enable_bzlmod=true": CompatibleVersions(minimum="6.2.0", before="7.0.0"),
-    # Incompatible changes
+    # Experimental changes we want to be compatible for
+    "--noexperimental_python_import_all_repositories": CompatibleVersions(minimum="1.0.0"),
+    # Preparation for incompatible changes
     "--incompatible_legacy_local_fallback=false": CompatibleVersions(minimum="5.0.0"),  # false is the forward path
     "--incompatible_enforce_config_setting_visibility": CompatibleVersions(minimum="5.0.0"),
     "--incompatible_config_setting_private_default_visibility": CompatibleVersions(minimum="5.0.0"),

--- a/third_party/pcpp/pcpp.BUILD
+++ b/third_party/pcpp/pcpp.BUILD
@@ -3,5 +3,6 @@ load("@rules_python//python:py_library.bzl", "py_library")
 py_library(
     name = "pcpp",
     srcs = glob(["pcpp/**/*"]),
+    imports = ["."],
     visibility = ["@depend_on_what_you_use//:__subpackages__"],
 )


### PR DESCRIPTION
Some users require this setting to mitigate issues due to a large `PYTHONPATH` created by rules_python.

Fixes: https://github.com/martis42/depend_on_what_you_use/issues/293