### PR TITLE
refactor(ci): Drop superfluous release step and ease BCR deployment

### DIFF
--- a/.github/workflows/prepare_release.py
+++ b/.github/workflows/prepare_release.py
@@ -14,10 +14,9 @@ import subprocess
 from pathlib import Path
 
 RELEASE_NOTES_TEMPLATE = """
-## Using Bzlmod (Recommended)
+:construction: **DO NOT USE. THIS IS STILL A DRAFT** :construction:
 
-> :construction: Not yet deployed to BCR :construction:
-> Release will become usable via bzlmod as soon as it is no longer the pre-release phase.
+## Using Bzlmod (Recommended)
 
 Add to your `MODULE.bazel` file:
 
@@ -67,7 +66,7 @@ def cli() -> argparse.Namespace:
 def make_archive(tag: str) -> Path:
     """
     The prefix is the same as what GitHub generates for source archives.
-    Thus, users cans easily switch between the released archives and the source archives generated for reach commit.
+    Thus, users can easily switch between the released archives and the source archives generated for reach commit.
 
     We can filter out some files via a .gitignore file. see:
     https://github.com/bazel-contrib/rules-template/blob/4e541c8083645da37eb570c23e04dc65e1d6446c/.gitattributes

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Draft release
         uses: softprops/action-gh-release@v2
         with:
-          draft: true
+          draft: false
           prerelease: true
           generate_release_notes: true
           body_path: release_notes.txt


### PR DESCRIPTION
We can't use draft releases. With drafts, the attached artifacts have a temporary download path different from the one available in the final release. This makes it impossible to use a draft Release for creating the BCR PR.