### PR TITLE
fix(aspect): Ignore non cc deps in target_mapping

### DIFF
--- a/src/cc_info_mapping/private/direct_deps.bzl
+++ b/src/cc_info_mapping/private/direct_deps.bzl
@@ -3,9 +3,15 @@ load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load(":providers.bzl", "DwyuCcInfoRemapInfo")
 
 def _aggregate_direct_deps_aspect_impl(target, ctx):
+    """
+    We deliberately ignore implementation_deps since headers provided by them shall by design not be used by consumers
+    of the target.
+    """
+
+    # 'cc_*' targets can depend on things like sh_library not providing CcInfo
+    cc_targets = [target] + [dep for dep in ctx.rule.attr.deps if CcInfo in dep]
     aggregated_compilation_context = cc_common.merge_compilation_contexts(
-        compilation_contexts =
-            [tgt[CcInfo].compilation_context for tgt in [target] + ctx.rule.attr.deps],
+        compilation_contexts = [tgt[CcInfo].compilation_context for tgt in cc_targets],
     )
 
     return DwyuCcInfoRemapInfo(target = target.label, cc_info = CcInfo(

--- a/src/cc_info_mapping/private/transitive_deps.bzl
+++ b/src/cc_info_mapping/private/transitive_deps.bzl
@@ -3,6 +3,10 @@ load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load(":providers.bzl", "DwyuCcInfoRemapInfo")
 
 def _aggregate_transitive_deps_aspect_impl(target, ctx):
+    # 'cc_*' targets can depend on things like sh_library not providing CcInfo at all
+    if CcInfo not in target:
+        return DwyuCcInfoRemapInfo(target = target.label, cc_info = CcInfo())
+
     all_cc_info = [target[CcInfo]]
     all_cc_info.extend([dep[DwyuCcInfoRemapInfo].cc_info for dep in ctx.rule.attr.deps])
     aggregated_compilation_context = cc_common.merge_compilation_contexts(
@@ -17,6 +21,7 @@ def _aggregate_transitive_deps_aspect_impl(target, ctx):
 _aggregate_transitive_deps_aspect = aspect(
     implementation = _aggregate_transitive_deps_aspect_impl,
     provides = [DwyuCcInfoRemapInfo],
+    # We deliberately ignore implementation_deps since headers provided by them shall by design not be used by consumers of the target
     attr_aspects = ["deps"],
 )
 

--- a/test/aspect/target_mapping/libs/BUILD
+++ b/test/aspect/target_mapping/libs/BUILD
@@ -2,17 +2,30 @@ cc_library(
     name = "a",
     hdrs = ["a.h"],
     visibility = ["//target_mapping:__subpackages__"],
-    deps = [":b"],
+    deps = [
+        ":b",
+        # Test travsing direct deps is robust against non C/CPP deps
+        ":non_cc_thing",
+    ],
 )
 
 cc_library(
     name = "b",
     hdrs = ["b.h"],
     visibility = ["//target_mapping/mapping:__pkg__"],
-    deps = [":c"],
+    deps = [
+        ":c",
+        # Test travsing transitive deps is robust against non C/CPP deps
+        ":non_cc_thing",
+    ],
 )
 
 cc_library(
     name = "c",
     hdrs = ["c.h"],
+)
+
+sh_library(
+    name = "non_cc_thing",
+    srcs = ["non_cc_thing.sh"],
 )


### PR DESCRIPTION
Resolves an issue reported in context of https://github.com/martis42/depend_on_what_you_use/issues/341

Based on this contribution https://github.com/martis42/depend_on_what_you_use/pull/342. I extended the fix to direct deps management and added tests