### PR TITLE
test(aspect): Support and use more dynamic version specifiers

### DIFF
--- a/test/aspect/execute_tests.py
+++ b/test/aspect/execute_tests.py
@@ -22,9 +22,9 @@ logging.basicConfig(format="%(message)s", level=logging.INFO)
 TESTED_VERSIONS = [
     TestedVersions(bazel="6.4.0", python="3.8"),
     TestedVersions(bazel="7.0.0", python="3.9"),
-    TestedVersions(bazel="7.5.0", python="3.10"),
+    TestedVersions(bazel="7.x", python="3.10"),
     TestedVersions(bazel="8.0.0", python="3.11"),
-    TestedVersions(bazel="8.0.1", python="3.12", is_default=True),
+    TestedVersions(bazel="8.x", python="3.12", is_default=True),
     TestedVersions(bazel="rolling", python="3.13"),
 ]
 


### PR DESCRIPTION
Allows us to test the latest Bazel versions with less maintenance effort due to regularly bumping versions.