### PR TITLE
test(bcr): Fix presubmit tests Bazel versions

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: "examples"
   matrix:
     platform: [ "macos", "ubuntu2204", "windows" ]
-    bazel: [ "6.4", "7.x", "8.x", "rolling" ]
+    bazel: [ "6.x", "7.x", "8.x", "rolling" ]
   tasks:
     verify_examples:
       name: "Verify examples"


### PR DESCRIPTION
One cannot omit the patch version. We now simply use the latest version of Bazel 6.
We wanted to use explicitly 6.4.x as this is our minimum required version. There is however no compelling reason to use the BCR to test our minimal required Bazel version. Our own CI already takes care of testing this.