### PR TITLE
perf: Concurrent & optional pre-processing

### DIFF
--- a/src/analyze_includes/main.py
+++ b/src/analyze_includes/main.py
@@ -69,6 +69,16 @@ def cli() -> Namespace:
         If this Bazel 5.0 feature is available, then check if some dependencies could be private instead of public.
         Meaning headers from them are only used in the private files.""",
     )
+    parser.add_argument(
+        "--multi_core",
+        action="store_true",
+        help="Use multiple cores to analyze the files.",
+    )
+    parser.add_argument(
+        "--no_preprocessor",
+        action="store_true",
+        help="Do not use the preprocessor to analyze the files.",
+    )
     return parser.parse_args()
 
 
@@ -85,12 +95,16 @@ def main(args: Namespace) -> int:
         ignored_includes=ignored_includes,
         defines=system_under_inspection.defines,
         include_paths=system_under_inspection.include_paths,
+        multi_core=args.multi_core,
+        no_preprocessor=args.no_preprocessor,
     )
     all_includes_from_private = get_relevant_includes_from_files(
         files=args.private_files,
         ignored_includes=ignored_includes,
         defines=system_under_inspection.defines,
         include_paths=system_under_inspection.include_paths,
+        multi_core=args.multi_core,
+        no_preprocessor=args.no_preprocessor,
     )
 
     result = evaluate_includes(

--- a/src/analyze_includes/test/parse_source_test.py
+++ b/src/analyze_includes/test/parse_source_test.py
@@ -100,19 +100,19 @@ class TestFilterIncludes(unittest.TestCase):
 class TestGetIncludesFromFile(unittest.TestCase):
     def test_empty_header(self) -> None:
         test_file = Path("src/analyze_includes/test/data/empty_header.h")
-        result = get_includes_from_file(test_file, defines=[], include_paths=[])
+        result = get_includes_from_file(test_file, defines=[], include_paths=[], no_preprocessor=False)
 
         self.assertEqual(result, [])
 
     def test_single_include(self) -> None:
         test_file = Path("src/analyze_includes/test/data/another_header.h")
-        result = get_includes_from_file(test_file, defines=[], include_paths=[])
+        result = get_includes_from_file(test_file, defines=[], include_paths=[], no_preprocessor=False)
 
         self.assertEqual(result, [Include(file=test_file, include="foo/bar.h")])
 
     def test_multiple_includes(self) -> None:
         test_file = Path("src/analyze_includes/test/data/some_header.h")
-        result = get_includes_from_file(test_file, defines=[], include_paths=[])
+        result = get_includes_from_file(test_file, defines=[], include_paths=[], no_preprocessor=False)
 
         self.assertEqual(len(result), 4)
         self.assertTrue(Include(file=test_file, include="bar.h") in result)
@@ -121,7 +121,7 @@ class TestGetIncludesFromFile(unittest.TestCase):
 
     def test_commented_includes_single_line_comments(self) -> None:
         test_file = Path("src/analyze_includes/test/data/commented_includes/single_line_comments.h")
-        result = get_includes_from_file(test_file, defines=[], include_paths=[])
+        result = get_includes_from_file(test_file, defines=[], include_paths=[], no_preprocessor=False)
 
         self.assertEqual(len(result), 2)
         self.assertTrue(Include(file=test_file, include="active_a.h") in result)
@@ -129,7 +129,7 @@ class TestGetIncludesFromFile(unittest.TestCase):
 
     def test_commented_includes_block_comments(self) -> None:
         test_file = Path("src/analyze_includes/test/data/commented_includes/block_comments.h")
-        result = get_includes_from_file(test_file, defines=[], include_paths=[])
+        result = get_includes_from_file(test_file, defines=[], include_paths=[], no_preprocessor=False)
 
         self.assertEqual(len(result), 8)
         self.assertTrue(Include(file=test_file, include="active_a.h") in result)
@@ -143,13 +143,13 @@ class TestGetIncludesFromFile(unittest.TestCase):
 
     def test_commented_includes_mixed_style(self) -> None:
         test_file = Path("src/analyze_includes/test/data/commented_includes/mixed_style.h")
-        result = get_includes_from_file(test_file, defines=[], include_paths=[])
+        result = get_includes_from_file(test_file, defines=[], include_paths=[], no_preprocessor=False)
 
         self.assertEqual(result, [Include(file=test_file, include="active.h")])
 
     def test_includes_selected_through_defines(self) -> None:
         test_file = Path("src/analyze_includes/test/data/header_with_defines.h")
-        result = get_includes_from_file(test_file, defines=["FOO", "BAZ 42"], include_paths=[])
+        result = get_includes_from_file(test_file, defines=["FOO", "BAZ 42"], include_paths=[], no_preprocessor=False)
 
         self.assertEqual(len(result), 4)
         self.assertTrue(Include(file=test_file, include="has_internal.h") in result)
@@ -159,7 +159,7 @@ class TestGetIncludesFromFile(unittest.TestCase):
 
     def test_includes_selected_through_defines_from_header(self) -> None:
         test_file = Path("src/analyze_includes/test/data/use_defines.h")
-        result = get_includes_from_file(test_file, defines=[], include_paths=[])
+        result = get_includes_from_file(test_file, defines=[], include_paths=[], no_preprocessor=False)
 
         self.assertEqual(len(result), 3)
         self.assertTrue(Include(file=test_file, include="src/analyze_includes/test/data/some_defines.h") in result)
@@ -168,7 +168,7 @@ class TestGetIncludesFromFile(unittest.TestCase):
 
     def test_include_based_on_pre_processor_token(self) -> None:
         test_file = Path("src/analyze_includes/test/data/include_based_on_pre_processor_token.h")
-        result = get_includes_from_file(test_file, defines=[], include_paths=[])
+        result = get_includes_from_file(test_file, defines=[], include_paths=[], no_preprocessor=False)
 
         self.assertEqual(len(result), 1)
         self.assertTrue(Include(file=test_file, include="some/header.h") in result)
@@ -181,6 +181,8 @@ class TestGetRelevantIncludesFromFiles(unittest.TestCase):
             ignored_includes=IgnoredIncludes(paths=["vector"], patterns=[]),
             defines=[],
             include_paths=[],
+            no_preprocessor=False,
+            multi_core=False,
         )
 
         self.assertEqual(len(result), 4)

--- a/src/aspect/dwyu.bzl
+++ b/src/aspect/dwyu.bzl
@@ -329,6 +329,10 @@ def dwyu_aspect_impl(target, ctx):
         args.add("--ignored_includes_config", ctx.files._ignored_includes[0])
     if _do_ensure_private_deps(ctx):
         args.add("--implementation_deps_available")
+    if ctx.attr._multi_core:
+        args.add("--multi_core")
+    if ctx.attr._no_preprocessor:
+        args.add("--no_preprocessor")
 
     all_hdrs = target[CcInfo].compilation_context.headers.to_list()
     analysis_inputs = [processed_target] + ctx.files._ignored_includes + processed_deps + processed_impl_deps + private_files + all_hdrs

--- a/src/aspect/factory.bzl
+++ b/src/aspect/factory.bzl
@@ -5,6 +5,8 @@ _DEFAULT_SKIPPED_TAGS = ["no-dwyu"]
 
 def dwyu_aspect_factory(
         experimental_set_cplusplus = False,
+        experimental_multi_core = False,
+        experimental_no_preprocessor = False,
         ignored_includes = None,
         recursive = False,
         skip_external_targets = False,
@@ -36,6 +38,16 @@ def dwyu_aspect_factory(
                                       If a common compiler option is used to set the C++ standard with an known value, set `__cplusplus` according to [this map](https://en.cppreference.com/w/cpp/preprocessor/replace#Predefined_macros).
                                     </li></ul>
                                     This feature is demonstrated in the [set_cpp_standard example](/examples/set_cpp_standard).
+
+        experimental_multi_core: **Experimental** feature whose behavior is not yet stable and an change at any time.<br>
+                                 By default, DWYU uses a single core per library to run the preprocessor.
+                                 This makes it use as many as there are cores.
+
+        experimental_no_preprocessor: **Experimental** feature whose behavior is not yet stable and an change at any time.<br>
+                                      By default, DWYU uses the pcpp to pre-process the source code.
+                                      This is necessary to get the correct include statements and the correct set of dependencies.
+                                      However, for large projects this can take a lot of time.
+                                      If your code doesn't use conditional includes, you can use this option.
 
         ignored_includes: By default, DWYU ignores all headers from the standard library when comparing include statements to the dependencies.
                           This list of headers can be seen in [std_header.py](/src/analyze_includes/std_header.py).<br>
@@ -112,6 +124,12 @@ def dwyu_aspect_factory(
             "_ignored_includes": attr.label_list(
                 default = aspect_ignored_includes,
                 allow_files = [".json"],
+            ),
+            "_multi_core": attr.bool(
+                default = experimental_multi_core,
+            ),
+            "_no_preprocessor": attr.bool(
+                default = experimental_no_preprocessor,
             ),
             "_process_target": attr.label(
                 default = Label("@depend_on_what_you_use//src/aspect:process_target"),


### PR DESCRIPTION
This implements a pair of workarounds for #350.

* One is to use multi-core (most useful work working on a single target)
* One is to entirely skip using the preprocessor (even faster).

Another option could be to instead add the ability to call out to the pre-processor from a hermetic toolchain. However, we don't use conditional includes, so these workarounds works for me.