### PR TITLE
refactoring: Rename providers for CcInfo remapping feature

### DIFF
--- a/src/aspect/dwyu.bzl
+++ b/src/aspect/dwyu.bzl
@@ -1,4 +1,4 @@
-load("@depend_on_what_you_use//src/cc_info_mapping:providers.bzl", "DwyuCcInfoRemappingsInfo")
+load("@depend_on_what_you_use//src/cc_info_mapping:providers.bzl", "DwyuCcInfoMappingInfo")
 load("@depend_on_what_you_use//src/cc_toolchain_headers:providers.bzl", "DwyuCcToolchainHeadersInfo")
 load("@rules_cc//cc:action_names.bzl", "CPP_COMPILE_ACTION_NAME")
 load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
@@ -208,7 +208,7 @@ def _gather_defines(ctx, target_compilation_context, target_files):
 
 def _exchange_cc_info(deps, mapping):
     transformed = []
-    mapping_info = mapping[0][DwyuCcInfoRemappingsInfo].mapping
+    mapping_info = mapping[0][DwyuCcInfoMappingInfo].mapping
     for dep in deps:
         if dep.label in mapping_info:
             transformed.append(struct(label = dep.label, cc_info = mapping_info[dep.label]))

--- a/src/aspect/factory.bzl
+++ b/src/aspect/factory.bzl
@@ -1,4 +1,4 @@
-load("@depend_on_what_you_use//src/cc_info_mapping:providers.bzl", "DwyuCcInfoRemappingsInfo")
+load("@depend_on_what_you_use//src/cc_info_mapping:providers.bzl", "DwyuCcInfoMappingInfo")
 load("@depend_on_what_you_use//src/cc_toolchain_headers:providers.bzl", "DwyuCcToolchainHeadersInfo")
 load("@rules_cc//cc:find_cc_toolchain.bzl", "use_cc_toolchain")
 load(":dwyu.bzl", "dwyu_aspect_impl")
@@ -186,7 +186,7 @@ def dwyu_aspect_factory(
                 default = aspect_skipped_tags,
             ),
             "_target_mapping": attr.label_list(
-                providers = [DwyuCcInfoRemappingsInfo],
+                providers = [DwyuCcInfoMappingInfo],
                 default = aspect_target_mapping,
             ),
             "_use_implementation_deps": attr.bool(

--- a/src/cc_info_mapping/cc_info_mapping.bzl
+++ b/src/cc_info_mapping/cc_info_mapping.bzl
@@ -25,25 +25,25 @@ Then a test can specify only the dependency to `@com_google_googletest//:gtest_m
 
 load("@depend_on_what_you_use//src/cc_info_mapping/private:direct_deps.bzl", "mapping_to_direct_deps")
 load("@depend_on_what_you_use//src/cc_info_mapping/private:explicit.bzl", "explicit_mapping")
-load("@depend_on_what_you_use//src/cc_info_mapping/private:providers.bzl", "DwyuCcInfoRemapInfo")
+load("@depend_on_what_you_use//src/cc_info_mapping/private:providers.bzl", "DwyuRemappedCcInfo")
 load("@depend_on_what_you_use//src/cc_info_mapping/private:transitive_deps.bzl", "mapping_to_transitive_deps")
 load("@depend_on_what_you_use//src/utils:utils.bzl", "label_to_name")
-load(":providers.bzl", "DwyuCcInfoRemappingsInfo")
+load(":providers.bzl", "DwyuCcInfoMappingInfo")
 
 MAP_DIRECT_DEPS = "__DWYU_MAP_DIRECT_DEPS__"
 MAP_TRANSITIVE_DEPS = "__DWYU_MAP_TRANSITIVE_DEPS__"
 
 def _make_remapping_info_impl(ctx):
-    return DwyuCcInfoRemappingsInfo(mapping = {
-        remap[DwyuCcInfoRemapInfo].target: remap[DwyuCcInfoRemapInfo].cc_info
+    return DwyuCcInfoMappingInfo(mapping = {
+        remap[DwyuRemappedCcInfo].target: remap[DwyuRemappedCcInfo].cc_info
         for remap in ctx.attr.remappings
     })
 
 _make_remapping_info = rule(
     implementation = _make_remapping_info_impl,
-    provides = [DwyuCcInfoRemappingsInfo],
+    provides = [DwyuCcInfoMappingInfo],
     attrs = {
-        "remappings": attr.label_list(providers = [DwyuCcInfoRemapInfo]),
+        "remappings": attr.label_list(providers = [DwyuRemappedCcInfo]),
     },
 )
 

--- a/src/cc_info_mapping/private/direct_deps.bzl
+++ b/src/cc_info_mapping/private/direct_deps.bzl
@@ -1,6 +1,6 @@
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
-load(":providers.bzl", "DwyuCcInfoRemapInfo")
+load(":providers.bzl", "DwyuRemappedCcInfo")
 
 def _aggregate_direct_deps_aspect_impl(target, ctx):
     """
@@ -14,23 +14,23 @@ def _aggregate_direct_deps_aspect_impl(target, ctx):
         compilation_contexts = [tgt[CcInfo].compilation_context for tgt in cc_targets],
     )
 
-    return DwyuCcInfoRemapInfo(target = target.label, cc_info = CcInfo(
+    return DwyuRemappedCcInfo(target = target.label, cc_info = CcInfo(
         compilation_context = aggregated_compilation_context,
         linking_context = target[CcInfo].linking_context,
     ))
 
 _aggregate_direct_deps_aspect = aspect(
     implementation = _aggregate_direct_deps_aspect_impl,
-    provides = [DwyuCcInfoRemapInfo],
+    provides = [DwyuRemappedCcInfo],
     attr_aspects = [],
 )
 
 def _mapping_to_direct_deps_impl(ctx):
-    return ctx.attr.target[DwyuCcInfoRemapInfo]
+    return ctx.attr.target[DwyuRemappedCcInfo]
 
 mapping_to_direct_deps = rule(
     implementation = _mapping_to_direct_deps_impl,
-    provides = [DwyuCcInfoRemapInfo],
+    provides = [DwyuRemappedCcInfo],
     attrs = {
         "target": attr.label(aspects = [_aggregate_direct_deps_aspect], providers = [CcInfo]),
     },

--- a/src/cc_info_mapping/private/explicit.bzl
+++ b/src/cc_info_mapping/private/explicit.bzl
@@ -1,6 +1,6 @@
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
-load(":providers.bzl", "DwyuCcInfoRemapInfo")
+load(":providers.bzl", "DwyuRemappedCcInfo")
 
 def _explicit_mapping_impl(ctx):
     aggregated_compilation_context = cc_common.merge_compilation_contexts(
@@ -8,14 +8,14 @@ def _explicit_mapping_impl(ctx):
             [tgt[CcInfo].compilation_context for tgt in [ctx.attr.target] + ctx.attr.map_to],
     )
 
-    return DwyuCcInfoRemapInfo(target = ctx.attr.target.label, cc_info = CcInfo(
+    return DwyuRemappedCcInfo(target = ctx.attr.target.label, cc_info = CcInfo(
         compilation_context = aggregated_compilation_context,
         linking_context = ctx.attr.target[CcInfo].linking_context,
     ))
 
 explicit_mapping = rule(
     implementation = _explicit_mapping_impl,
-    provides = [DwyuCcInfoRemapInfo],
+    provides = [DwyuRemappedCcInfo],
     attrs = {
         "map_to": attr.label_list(providers = [CcInfo]),
         "target": attr.label(providers = [CcInfo]),

--- a/src/cc_info_mapping/private/providers.bzl
+++ b/src/cc_info_mapping/private/providers.bzl
@@ -1,4 +1,4 @@
-DwyuCcInfoRemapInfo = provider(
+DwyuRemappedCcInfo = provider(
     "An alternative CcInfo object for a target which can be used by DWYU during the analysis",
     fields = {
         "cc_info": "CcInfo provider",

--- a/src/cc_info_mapping/private/transitive_deps.bzl
+++ b/src/cc_info_mapping/private/transitive_deps.bzl
@@ -1,36 +1,36 @@
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
-load(":providers.bzl", "DwyuCcInfoRemapInfo")
+load(":providers.bzl", "DwyuRemappedCcInfo")
 
 def _aggregate_transitive_deps_aspect_impl(target, ctx):
     # 'cc_*' targets can depend on things like sh_library not providing CcInfo at all
     if CcInfo not in target:
-        return DwyuCcInfoRemapInfo(target = target.label, cc_info = CcInfo())
+        return DwyuRemappedCcInfo(target = target.label, cc_info = CcInfo())
 
     all_cc_info = [target[CcInfo]]
-    all_cc_info.extend([dep[DwyuCcInfoRemapInfo].cc_info for dep in ctx.rule.attr.deps])
+    all_cc_info.extend([dep[DwyuRemappedCcInfo].cc_info for dep in ctx.rule.attr.deps])
     aggregated_compilation_context = cc_common.merge_compilation_contexts(
         compilation_contexts = [cci.compilation_context for cci in all_cc_info],
     )
 
-    return DwyuCcInfoRemapInfo(target = target.label, cc_info = CcInfo(
+    return DwyuRemappedCcInfo(target = target.label, cc_info = CcInfo(
         compilation_context = aggregated_compilation_context,
         linking_context = target[CcInfo].linking_context,
     ))
 
 _aggregate_transitive_deps_aspect = aspect(
     implementation = _aggregate_transitive_deps_aspect_impl,
-    provides = [DwyuCcInfoRemapInfo],
+    provides = [DwyuRemappedCcInfo],
     # We deliberately ignore implementation_deps since headers provided by them shall by design not be used by consumers of the target
     attr_aspects = ["deps"],
 )
 
 def _mapping_to_transitive_deps_impl(ctx):
-    return ctx.attr.target[DwyuCcInfoRemapInfo]
+    return ctx.attr.target[DwyuRemappedCcInfo]
 
 mapping_to_transitive_deps = rule(
     implementation = _mapping_to_transitive_deps_impl,
-    provides = [DwyuCcInfoRemapInfo],
+    provides = [DwyuRemappedCcInfo],
     attrs = {
         "target": attr.label(aspects = [_aggregate_transitive_deps_aspect], providers = [CcInfo]),
     },

--- a/src/cc_info_mapping/providers.bzl
+++ b/src/cc_info_mapping/providers.bzl
@@ -1,4 +1,4 @@
-DwyuCcInfoRemappingsInfo = provider(
+DwyuCcInfoMappingInfo = provider(
     "Mapping of targets to CcInfo providers which DWYU should use for analysis instead of the targets original CcInfo.",
     fields = {
         "mapping": "Dictionary with structure {'target label': CcInfo}",


### PR DESCRIPTION
BREAKING CHANGE: The old names were easily mixed up. `DwyuCcInfoRemappingsInfo` was publily visible. Thus, this is a breaking change. But users were never expected to use it, so this has most likely no real impact.