### PR TITLE
test(benchmark): Fix broken execution

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -36,7 +36,7 @@ test/aspect/using_transitive_dep
 test/aspect/valid
 test/aspect/virtual_includes
 
-test/benchmark/generated
+test/benchmark
 
 test/cc_toolchains/mocked
 

--- a/test/benchmark/.bazelrc
+++ b/test/benchmark/.bazelrc
@@ -1,0 +1,11 @@
+# Do not waste memory by keeping idle Bazel servers around
+startup --max_idle_secs=10
+
+# Always tell why tests fail
+test --test_output=errors
+
+# The benchmarks don't care about higher versions than expected for our dependencies being used
+common --check_direct_dependencies=off
+
+# The symlinks are cluttering the file tree without much value
+common --experimental_convenience_symlinks=ignore

--- a/test/benchmark/.bazelversion
+++ b/test/benchmark/.bazelversion
@@ -1,0 +1,1 @@
+../../.bazelversion

--- a/test/benchmark/MODULE.bazel
+++ b/test/benchmark/MODULE.bazel
@@ -1,0 +1,14 @@
+module(name = "dwyu_benchmarks")
+
+bazel_dep(name = "depend_on_what_you_use")
+local_path_override(
+    module_name = "depend_on_what_you_use",
+    path = "../../",
+)
+
+bazel_dep(name = "googletest", version = "1.17.0")
+
+# We specify by design an outdated rules_cc version.
+# bzlmod resolves dependencies to the maximum of all requested versions for all involved modules.
+# Specifying an ancient version here gives us in the end at least whatever rules_cc version DWYU defines as dependency.
+bazel_dep(name = "rules_cc", version = "0.0.1")

--- a/test/benchmark/bench_many_targets.py
+++ b/test/benchmark/bench_many_targets.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import sys
 from pathlib import Path
 from shutil import rmtree
@@ -32,8 +33,8 @@ JOBS = -1
 # Generation templates
 #
 
-TEST_DIR = "test/benchmark/generated/many_targets"
-OUTPUT_DIR = WS_ROOT / TEST_DIR
+BENCHMARKS_DIR = WS_ROOT / "test/benchmark"
+OUTPUT_DIR = BENCHMARKS_DIR / "generated/many_targets"
 
 LIB_TEMPLATE = """
 #ifndef LIB_HEADER_{N}_H
@@ -116,8 +117,11 @@ def main() -> None:
     """
     create_test_setup()
 
-    primer = "//test/benchmark/generated/many_targets:primer"
-    target = "//test/benchmark/generated/many_targets/..."
+    # Execute the Bazel commands from within the benchmarks workspace
+    os.chdir(BENCHMARKS_DIR)
+
+    primer = "//generated/many_targets:primer"
+    target = "//generated/many_targets/..."
     run_benchmark(
         aspect="dwyu_legacy_default",
         primer=primer,

--- a/test/benchmark/bench_target_with_complex_code.py
+++ b/test/benchmark/bench_target_with_complex_code.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import sys
 from pathlib import Path
 from shutil import rmtree
@@ -29,7 +30,8 @@ JOBS = 1
 # Generation templates
 #
 
-OUTPUT_DIR = WS_ROOT / "test/benchmark/generated/complex_code"
+BENCHMARKS_DIR = WS_ROOT / "test/benchmark"
+OUTPUT_DIR = BENCHMARKS_DIR / "generated/complex_code"
 
 TEMPLATE = """
 #include "gmock/gmock.h"
@@ -110,8 +112,11 @@ def main() -> None:
     """
     create_test_setup()
 
-    primer = "//test/benchmark/generated/complex_code:primer"
-    target = "//test/benchmark/generated/complex_code:benchmark"
+    # Execute the Bazel commands from within the benchmarks workspace
+    os.chdir(BENCHMARKS_DIR)
+
+    primer = "//generated/complex_code:primer"
+    target = "//generated/complex_code:benchmark"
     run_benchmark(
         aspect="dwyu_legacy_default",
         primer=primer,

--- a/test/benchmark/bench_target_with_many_files.py
+++ b/test/benchmark/bench_target_with_many_files.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import sys
 from pathlib import Path
 from shutil import rmtree
@@ -30,7 +31,8 @@ JOBS = 1
 # Generation templates
 #
 
-OUTPUT_DIR = WS_ROOT / "test/benchmark/generated/many_files"
+BENCHMARKS_DIR = WS_ROOT / "test/benchmark"
+OUTPUT_DIR = BENCHMARKS_DIR / "generated/many_files"
 LIB_DIR = OUTPUT_DIR / "lib"
 
 CORE_LIB_HEADER = """
@@ -179,8 +181,11 @@ def main() -> None:
     """
     create_test_setup()
 
-    primer = "//test/benchmark/generated/many_files:primer"
-    target = "//test/benchmark/generated/many_files:benchmark"
+    # Execute the Bazel commands from within the benchmarks workspace
+    os.chdir(BENCHMARKS_DIR)
+
+    primer = "//generated/many_files:primer"
+    target = "//generated/many_files:benchmark"
     run_benchmark(
         aspect="dwyu_legacy_default",
         primer=primer,

--- a/test/benchmark/lib.py
+++ b/test/benchmark/lib.py
@@ -32,7 +32,7 @@ def run_benchmark(aspect: str, primer: str, bench_target: str, description: str,
         "--check_direct_dependencies=off",
         "--output_groups=dwyu",
     ]
-    cmd_dwyu = [*cmd_base, f"--aspects=//test/benchmark:aspect.bzl%{aspect}"]
+    cmd_dwyu = [*cmd_base, f"--aspects=//:aspect.bzl%{aspect}"]
 
     log.info(f"#### Running Benchmark - {description}")
     times = []


### PR DESCRIPTION
The benchmarks need to be an own workspace, so the are not influenced by the root level `.bazelignore` file.