### PR TITLE
ci: Do not automatically rebase renovate PRs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,7 +5,6 @@
     ":dependencyDashboard",
     ":enablePreCommit",
     "schedule:monthly",
-    ":rebaseStalePrs",
     ":semanticCommits",
     ":semanticPrefixChore",
     ":label(renovate)"


### PR DESCRIPTION
This is a waste of time and resources, given most renovate are trivial updates with minimal risk. If we feel like we only want to merge them after a CI run based on head, we can always manually rebase them.