### PR TITLE
test: Temporarily drop testing Bazel 9 and rolling

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -2,7 +2,8 @@ bcr_test_module:
   module_path: "examples"
   matrix:
     platform: [ "macos", "ubuntu2204", "windows" ]
-    bazel: [ "6.x", "7.x", "8.x", "rolling" ]
+    # Keep in syn with: test/aspect/execute_tests.py, test/workspace_integration/test.py, test/cc_toolchains/upstream/test.py
+    bazel: [ "6.x", "7.x", "8.x" ]
   tasks:
     verify_examples:
       name: "Verify examples"

--- a/test/aspect/execute_tests.py
+++ b/test/aspect/execute_tests.py
@@ -20,13 +20,13 @@ log = logging.getLogger()
 # Test matrix. We don't combine each Bazel version with each Python version as there is no significant benefit. We
 # manually define pairs which make sure each Bazel and Python version we care about is used at least once.
 # For versions using the legacy WORKSPACE setup we have to specify the patch version for Python
+# Keep this in sync with: test/workspace_integration/test.py, test/cc_toolchains/upstream/test.py, .bcr/presubmit.yml
 TESTED_VERSIONS = [
     TestedVersions(bazel="6.4.0", python="3.8"),
     TestedVersions(bazel="7.0.0", python="3.9"),
     TestedVersions(bazel="7.x", python="3.10"),
     TestedVersions(bazel="8.0.0", python="3.11"),
     TestedVersions(bazel="8.x", python="3.12", is_default=True),
-    TestedVersions(bazel="rolling", python="3.13"),
 ]
 
 VERSION_SPECIFIC_ARGS = {

--- a/test/cc_toolchains/upstream/test.py
+++ b/test/cc_toolchains/upstream/test.py
@@ -60,7 +60,7 @@ TOOLCHAINS = [
     ToolchainConfig(
         name="host_toolchain",
         source="https://github.com/bazelbuild/rules_cc",
-        bazel_versions=[BazelVersion("6.4.0"), BazelVersion("7.x"), BazelVersion("8.x"), BazelVersion("rolling")],
+        bazel_versions=[BazelVersion("6.4.0"), BazelVersion("7.x"), BazelVersion("8.x")],
         platforms=["Linux", "Darwin", "Windows"],
         extra_args=[],
         module_snippet="",
@@ -68,7 +68,7 @@ TOOLCHAINS = [
     ToolchainConfig(
         name="toolchains_llvm",
         source="https://github.com/bazel-contrib/toolchains_llvm",
-        bazel_versions=[BazelVersion("7.x"), BazelVersion("8.x"), BazelVersion("rolling")],
+        bazel_versions=[BazelVersion("7.x"), BazelVersion("8.x")],
         platforms=["Linux", "Darwin"],
         extra_args=["--config=no_default_toolchain"],
         module_snippet="""
@@ -113,7 +113,7 @@ register_toolchains("@zig_sdk//...")
     ToolchainConfig(
         name="toolchains_musl",
         source="https://github.com/bazel-contrib/musl-toolchain",
-        bazel_versions=[BazelVersion("6.4.0"), BazelVersion("7.x"), BazelVersion("8.x"), BazelVersion("rolling")],
+        bazel_versions=[BazelVersion("6.4.0"), BazelVersion("7.x"), BazelVersion("8.x")],
         # Cannot compile from Darwin to Darwin, just cross compile from Darwin to Linux. Cross compilation is not yet supported/tested though.
         platforms=["Linux"],
         extra_args=["--config=no_default_toolchain"],

--- a/test/workspace_integration/test.py
+++ b/test/workspace_integration/test.py
@@ -19,13 +19,13 @@ from test.support.bazel import get_bazel_binary, get_explicit_bazel_version, mak
 logging.basicConfig(format="%(message)s", level=logging.INFO)
 log = logging.getLogger()
 
+# Kep in sync with: test/aspect/execute_tests.py, test/cc_toolchains/upstream/test.py, .bcr/presubmit.yml
 BAZEL_VERSIONS_UNDER_TEST = [
     "6.4.0",
     "7.0.0",
     "7.x",
     "8.0.0",
     "8.x",
-    "rolling",
 ]
 
 


### PR DESCRIPTION
Bazel 9 is incompatible to our bzip2 and xz dependency. Updating them is unfortunately incompatible to Bazel 6.4.0.
However, we plan one last release supporting Bazel 6.4.0 and Bazel 9 was not yet even released.

Rolling, aka Bazel 10, is right now globally broken and cannot be tested at all, see https://github.com/bazelbuild/bazel/issues/27749