### PR TITLE
test(aspect): Fix relative includes tests

### DIFF
--- a/test/aspect/relative_includes/use_system_include.cpp
+++ b/test/aspect/relative_includes/use_system_include.cpp
@@ -3,7 +3,6 @@
 #include "some/sub/dir/foo.h"
 #include "system_include.h"
 // include from virtually prefixed path
-#include <../some/sub/dir/bar.h>
 #include <sub/../sub/dir/bar.h>
 
 int main() {

--- a/test/aspect/relative_includes/use_virtual_prefix.cpp
+++ b/test/aspect/relative_includes/use_virtual_prefix.cpp
@@ -2,10 +2,7 @@
 #include "some/sub/dir/../dir/bar.h"
 #include "some/sub/dir/bar.h"
 #include "virtual_prefix.h"
-// reach into virtual paths from repository root
-#include "relative_includes/_virtual_includes/virtual_prefix/custom/prefix/some/sub/dir/foo.h"
 // include from virtually prefixed path
-#include "../virtual_prefix/custom/prefix/some/sub/dir/foo.h"
 #include "custom/prefix/../prefix/some/sub/dir/foo.h"
 
 int main() {

--- a/test/aspect/relative_includes/use_virtual_strip.cpp
+++ b/test/aspect/relative_includes/use_virtual_strip.cpp
@@ -2,10 +2,7 @@
 #include "some/sub/dir/../dir/bar.h"
 #include "some/sub/dir/bar.h"
 #include "some/virtual_strip.h"
-// reach into virtual paths from repository root
-#include "relative_includes/_virtual_includes/virtual_strip/sub/dir/foo.h"
 // include from virtually stripped path
-#include "../virtual_strip/sub/dir/foo.h"
 #include "sub/dir/../dir/foo.h"
 
 int main() {


### PR DESCRIPTION
The exact file system layout behind virtual includes is an implementation detail one should not depend on. Thus, we should also not test this implementation detail.