### PR TITLE
feat(aspect): Simplify target usage logic

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -19,6 +19,7 @@
 # misc-non-private-member-variables-in-classes : Alias to cppcoreguidelines-non-private-member-variables-in-classes
 # modernize-avoid-c-arrays : Alias to cppcoreguidelines-avoid-c-arrays
 # modernize-make-unique : Not compatible to C++11
+# modernize-type-traits : Not compatible to C++11
 # modernize-use-default-member-init : Alias to cppcoreguidelines-use-default-member-init
 # modernize-use-nodiscard : Not compatible to C++11
 # modernize-use-trailing-return-type : We prefer the classic style
@@ -41,6 +42,7 @@ Checks: >
         -misc-non-private-member-variables-in-classes,
         -modernize-avoid-c-arrays,
         -modernize-make-unique,
+        -modernize-type-traits,
         -modernize-use-default-member-init,
         -modernize-use-nodiscard,
         -modernize-use-trailing-return-type,

--- a/dwyu/aspect/private/analyze_includes/system_under_inspection.cpp
+++ b/dwyu/aspect/private/analyze_includes/system_under_inspection.cpp
@@ -2,10 +2,11 @@
 
 #include "dwyu/aspect/private/analyze_includes/utility.h"
 
+#include <algorithm>
 #include <memory>
-#include <stdexcept>
 #include <string>
 #include <tuple>
+#include <type_traits>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -35,25 +36,16 @@ CcTargetUnderInspection getTargetUnderInspectionFromFile(const std::string& file
     return target;
 }
 
+template <class T>
+T maxEnum(const T lhs, const T rhs) {
+    using UnderlyingType = typename std::underlying_type<T>::type;
+    return static_cast<T>(std::max(static_cast<UnderlyingType>(lhs), static_cast<UnderlyingType>(rhs)));
+}
+
 } // namespace
 
-void TargetUsage::update(Status usage_update) {
-    if (usage_update == Status::None) {
-        throw std::invalid_argument{"Resetting the usage to 'None' is not supported"};
-    }
-
-    if (usage_ == Status::PublicAndPrivate) {
-        // The input cannot change anything
-        return;
-    }
-
-    if (!is_used() || usage_update == Status::PublicAndPrivate) {
-        usage_ = usage_update;
-    }
-    else if ((usage_ == Status::Private && usage_update == Status::Public) ||
-             (usage_ == Status::Public && usage_update == Status::Private)) {
-        usage_ = Status::PublicAndPrivate;
-    }
+void TargetUsage::update(const Status usage_update) {
+    usage_ = maxEnum(usage_, usage_update);
 }
 
 SystemUnderInspection getSystemUnderInspection(const std::string& target_under_inspection,

--- a/dwyu/aspect/private/analyze_includes/system_under_inspection.h
+++ b/dwyu/aspect/private/analyze_includes/system_under_inspection.h
@@ -14,9 +14,8 @@ class TargetUsage {
   public:
     enum class Status : std::uint_fast8_t {
         None,
-        Public,
         Private,
-        PublicAndPrivate,
+        Public,
     };
 
     void update(Status usage_update);

--- a/dwyu/aspect/private/analyze_includes/test/system_under_inspection_test.cpp
+++ b/dwyu/aspect/private/analyze_includes/test/system_under_inspection_test.cpp
@@ -6,7 +6,6 @@
 #include <algorithm>
 #include <memory>
 #include <ostream>
-#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -18,14 +17,11 @@ static void PrintTo(const dwyu::TargetUsage::Status& status, std::ostream* strea
     case dwyu::TargetUsage::Status::None:
         *stream << "None";
         break;
-    case dwyu::TargetUsage::Status::Public:
-        *stream << "Public";
-        break;
     case dwyu::TargetUsage::Status::Private:
         *stream << "Private";
         break;
-    case dwyu::TargetUsage::Status::PublicAndPrivate:
-        *stream << "PublicAndPrivate";
+    case dwyu::TargetUsage::Status::Public:
+        *stream << "Public";
         break;
     default:
         *stream << "UNKNOWN_STATUS";
@@ -81,41 +77,17 @@ INSTANTIATE_TEST_SUITE_P(
         // Single updates
         TargetUsageSpec{{TargetUsage::Status::Public}, TargetUsage::Status::Public},
         TargetUsageSpec{{TargetUsage::Status::Private}, TargetUsage::Status::Private},
-        TargetUsageSpec{{TargetUsage::Status::PublicAndPrivate}, TargetUsage::Status::PublicAndPrivate},
         // Multiple updates
-        TargetUsageSpec{{TargetUsage::Status::Public, TargetUsage::Status::Private},
-                        TargetUsage::Status::PublicAndPrivate},
         TargetUsageSpec{{TargetUsage::Status::Public, TargetUsage::Status::Public}, TargetUsage::Status::Public},
-        TargetUsageSpec{{TargetUsage::Status::Private, TargetUsage::Status::Public},
-                        TargetUsage::Status::PublicAndPrivate},
         TargetUsageSpec{{TargetUsage::Status::Private, TargetUsage::Status::Private}, TargetUsage::Status::Private},
-        // PublicAndPrivate always wins
-        TargetUsageSpec{{TargetUsage::Status::Public, TargetUsage::Status::PublicAndPrivate},
-                        TargetUsage::Status::PublicAndPrivate},
-        TargetUsageSpec{{TargetUsage::Status::Private, TargetUsage::Status::PublicAndPrivate},
-                        TargetUsage::Status::PublicAndPrivate},
-        TargetUsageSpec{{TargetUsage::Status::PublicAndPrivate, TargetUsage::Status::PublicAndPrivate},
-                        TargetUsage::Status::PublicAndPrivate},
-        TargetUsageSpec{{TargetUsage::Status::PublicAndPrivate, TargetUsage::Status::Public},
-                        TargetUsage::Status::PublicAndPrivate},
-        TargetUsageSpec{{TargetUsage::Status::PublicAndPrivate, TargetUsage::Status::Private},
-                        TargetUsage::Status::PublicAndPrivate}));
+        TargetUsageSpec{{TargetUsage::Status::Public, TargetUsage::Status::Private}, TargetUsage::Status::Public},
+        TargetUsageSpec{{TargetUsage::Status::Private, TargetUsage::Status::Public}, TargetUsage::Status::Public}));
 
 TEST(TargetUsage, ByDefaultIsNotUsed) {
     const TargetUsage unit{};
 
     EXPECT_FALSE(unit.is_used());
     EXPECT_EQ(unit.usage(), TargetUsage::Status::None);
-}
-
-TEST(TargetUsage, ResettingToUnusedIsNotAllowed) {
-    TargetUsage unit{};
-
-    EXPECT_THROW(unit.update(TargetUsage::Status::None), std::invalid_argument);
-    unit.update(TargetUsage::Status::Public);
-    EXPECT_THROW(unit.update(TargetUsage::Status::None), std::invalid_argument);
-    unit.update(TargetUsage::Status::Private);
-    EXPECT_THROW(unit.update(TargetUsage::Status::None), std::invalid_argument);
 }
 
 TEST(GetSystemUnderInspection, GivenTargetUnderInspectionReadAllDataCorrectly) {


### PR DESCRIPTION
We kept `PublicAndPrivate` when introducing the C++ implementation to keep the functional changes compared to the Python version minimal. However, actually we don't need this state. We can simply have `Public` overwrite `Private` and achieve the same result with respect to detecting if targets are used at all and if a cc_library `deps` target should be moved to `implementation_deps`.
Also we remove the special handling of the `None` state. This case was either way unrealistic due to this being our private code.