### PR TITLE
test(aspect): Ensure we can work with hdrs from 'srcs'

### DIFF
--- a/test/aspect/using_transitive_dep/BUILD
+++ b/test/aspect/using_transitive_dep/BUILD
@@ -1,25 +1,30 @@
 load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
-cc_library(
-    name = "foo",
-    hdrs = ["foo.h"],
-)
-
-cc_library(
-    name = "bar",
-    hdrs = ["bar.h"],
-    deps = [":foo"],
-)
-
 cc_binary(
     name = "main",
     srcs = ["main.cpp"],
-    deps = [":bar"],
+    deps = [":direct_dep"],
 )
 
 cc_library(
     name = "transitive_usage_through_impl_deps",
     srcs = ["transitive_usage_through_impl_deps.h"],
-    implementation_deps = [":bar"],
+    implementation_deps = [":direct_dep"],
+)
+
+##
+## Support
+##
+
+cc_library(
+    name = "direct_dep",
+    hdrs = ["direct_dep.h"],
+    deps = [":transitive_dep"],
+)
+
+cc_library(
+    name = "transitive_dep",
+    srcs = ["transitive_dep_src.h"],
+    hdrs = ["transitive_dep_hdr.h"],
 )

--- a/test/aspect/using_transitive_dep/bar.h
+++ b/test/aspect/using_transitive_dep/bar.h
@@ -1,9 +1,0 @@
-#ifndef BAR_H
-#define BAR_H
-#include "using_transitive_dep/foo.h"
-
-int doStuff() {
-    return theAnswer() + 1;
-}
-
-#endif

--- a/test/aspect/using_transitive_dep/direct_dep.h
+++ b/test/aspect/using_transitive_dep/direct_dep.h
@@ -1,0 +1,11 @@
+#ifndef USING_TRANSITIVE_DEP_DIRECT_DEP_H
+#define USING_TRANSITIVE_DEP_DIRECT_DEP_H
+
+#include "using_transitive_dep/transitive_dep_hdr.h"
+#include "using_transitive_dep/transitive_dep_src.h"
+
+int directDepFn() {
+    return transitiveDepFnA() + transitiveDepFnB();
+}
+
+#endif

--- a/test/aspect/using_transitive_dep/foo.h
+++ b/test/aspect/using_transitive_dep/foo.h
@@ -1,8 +1,0 @@
-#ifndef FOO_H
-#define FOO_H
-
-int theAnswer() {
-    return 42;
-}
-
-#endif

--- a/test/aspect/using_transitive_dep/main.cpp
+++ b/test/aspect/using_transitive_dep/main.cpp
@@ -1,9 +1,12 @@
-#include "using_transitive_dep/bar.h"
-#include "using_transitive_dep/foo.h"
+#include "using_transitive_dep/direct_dep.h"
+#include "using_transitive_dep/transitive_dep_hdr.h"
+// Including a header which is only available from the 'srcs' attribute of a cc_library is wrong. Unfortunately, Bazel
+// is not enforcing its own API design regarding this.
+// We test this case explicitly to ensure code using this anti pattern can be analyzed by DWYU. Our assumption of use
+// is that the code compiles, which this example does.
+#include "using_transitive_dep/transitive_dep_src.h"
 
 int main() {
     // ERROR: Using a function from library foo but depending only on library bar
-    const int answer = theAnswer();
-    const int stuff = doStuff();
-    return answer != stuff;
+    return directDepFn() + transitiveDepFnA() + transitiveDepFnB();
 }

--- a/test/aspect/using_transitive_dep/test_detect_using_transitive_dep.py
+++ b/test/aspect/using_transitive_dep/test_detect_using_transitive_dep.py
@@ -8,11 +8,17 @@ from test.support.result import Result
 
 class TestCase(TestCaseBase):
     def execute_test_logic(self) -> Result:
-        expected_invalid_includes = [
-            "In file 'using_transitive_dep/main.cpp' include: \"using_transitive_dep/foo.h\""
+        expected_invalid_includes = (
+            [
+                "In file 'using_transitive_dep/main.cpp' include: \"using_transitive_dep/transitive_dep_hdr.h\"",
+                "In file 'using_transitive_dep/main.cpp' include: \"using_transitive_dep/transitive_dep_src.h\"",
+            ]
             if self._cpp_impl_based
-            else f"File='{Path('using_transitive_dep/main.cpp')}', include='using_transitive_dep/foo.h'"
-        ]
+            else [
+                f"File='{Path('using_transitive_dep/main.cpp')}', include='using_transitive_dep/transitive_dep_hdr.h'",
+                f"File='{Path('using_transitive_dep/main.cpp')}', include='using_transitive_dep/transitive_dep_hdr.h'",
+            ]
+        )
         expected = ExpectedResult(
             success=False,
             invalid_includes=expected_invalid_includes,

--- a/test/aspect/using_transitive_dep/test_detect_using_transitive_impl_dep.py
+++ b/test/aspect/using_transitive_dep/test_detect_using_transitive_impl_dep.py
@@ -8,11 +8,17 @@ from test.support.result import Result
 
 class TestCase(TestCaseBase):
     def execute_test_logic(self) -> Result:
-        expected_invalid_includes = [
-            "In file 'using_transitive_dep/transitive_usage_through_impl_deps.h' include: \"using_transitive_dep/foo.h\""
+        expected_invalid_includes = (
+            [
+                "In file 'using_transitive_dep/transitive_usage_through_impl_deps.h' include: \"using_transitive_dep/transitive_dep_hdr.h\"",
+                "In file 'using_transitive_dep/transitive_usage_through_impl_deps.h' include: \"using_transitive_dep/transitive_dep_src.h\"",
+            ]
             if self._cpp_impl_based
-            else f"File='{Path('using_transitive_dep/transitive_usage_through_impl_deps.h')}', include='using_transitive_dep/foo.h'"
-        ]
+            else [
+                f"File='{Path('using_transitive_dep/transitive_usage_through_impl_deps.h')}', include='using_transitive_dep/transitive_dep_hdr.h'",
+                f"File='{Path('using_transitive_dep/transitive_usage_through_impl_deps.h')}', include='using_transitive_dep/transitive_dep_hdr.h'",
+            ]
+        )
         expected = ExpectedResult(
             success=False,
             invalid_includes=expected_invalid_includes,

--- a/test/aspect/using_transitive_dep/transitive_dep_hdr.h
+++ b/test/aspect/using_transitive_dep/transitive_dep_hdr.h
@@ -1,0 +1,8 @@
+#ifndef USING_TRANSITIVE_DEP_TRANSITIVE_DEP_HDR_H
+#define USING_TRANSITIVE_DEP_TRANSITIVE_DEP_HDR_H
+
+int transitiveDepFnA() {
+    return 4;
+}
+
+#endif

--- a/test/aspect/using_transitive_dep/transitive_dep_src.h
+++ b/test/aspect/using_transitive_dep/transitive_dep_src.h
@@ -1,0 +1,8 @@
+#ifndef USING_TRANSITIVE_DEP_TRANSITIVE_DEP_SRC_H
+#define USING_TRANSITIVE_DEP_TRANSITIVE_DEP_SRC_H
+
+int transitiveDepFnB() {
+    return 2;
+}
+
+#endif

--- a/test/aspect/using_transitive_dep/transitive_usage_through_impl_deps.h
+++ b/test/aspect/using_transitive_dep/transitive_usage_through_impl_deps.h
@@ -1,9 +1,12 @@
-#include "using_transitive_dep/bar.h"
-#include "using_transitive_dep/foo.h"
+#include "using_transitive_dep/direct_dep.h"
+#include "using_transitive_dep/transitive_dep_hdr.h"
+// Including a header which is only available from the 'srcs' attribute of a cc_library is wrong. Unfortunately, Bazel
+// is not enforcing its own API design regarding this.
+// We test this case explicitly to ensure code using this anti pattern can be analyzed by DWYU. Our assumption of use
+// is that the code compiles, which this example does.
+#include "using_transitive_dep/transitive_dep_src.h"
 
 int doSth() {
     // ERROR: Using a function from library foo but depending only on library bar
-    const int answer = theAnswer();
-    const int stuff = doStuff();
-    return answer != stuff;
+    return directDepFn() + transitiveDepFnA() + transitiveDepFnB();
 }


### PR DESCRIPTION
While doing so is actually an anti-pattern, it is still allowed by Bazel and often done by accident due to nor enforcement existing to prevent this.