### PR TITLE
test: Test again against Bazel "rolling", aka Bazel 10

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -2,8 +2,8 @@ bcr_test_module:
   module_path: "examples"
   matrix:
     platform: [ "macos", "ubuntu2204", "windows" ]
-    # Keep in syn with: test/aspect/execute_tests.py, test/workspace_integration/test.py, test/cc_toolchains/upstream/test.py
-    bazel: [ "7.2.1", "8.x", "9.*" ]
+    # Keep in syn with: test/aspect/execute_tests.py, test/cc_toolchains/upstream/test.py, test/workspace_integration/test.py
+    bazel: [ "7.2.1", "8.x", "9.*", "rolling" ]
   tasks:
     verify_examples:
       name: "Verify examples"

--- a/test/aspect/execute_tests.py
+++ b/test/aspect/execute_tests.py
@@ -20,12 +20,14 @@ log = logging.getLogger()
 # Test matrix. We don't combine each Bazel version with each Python version as there is no significant benefit. We
 # manually define pairs which make sure each Bazel and Python version we care about is used at least once.
 # For versions using the legacy WORKSPACE setup we have to specify the patch version for Python
-# Keep this in sync with: test/workspace_integration/test.py, test/cc_toolchains/upstream/test.py, .bcr/presubmit.yml
+#
+# Keep this in sync with: .bcr/presubmit.yml, test/cc_toolchains/upstream/test.py, test/workspace_integration/test.py
 TESTED_VERSIONS = [
     TestedVersions(bazel="7.2.1", python="3.8"),
     TestedVersions(bazel="7.x", python="3.10"),
     TestedVersions(bazel="8.x", python="3.12", is_default=True),
     TestedVersions(bazel="9.*", python="3.13"),
+    TestedVersions(bazel="rolling", python="3.13"),
 ]
 
 VERSION_SPECIFIC_ARGS = {

--- a/test/cc_toolchains/upstream/test.py
+++ b/test/cc_toolchains/upstream/test.py
@@ -56,11 +56,12 @@ class ToolchainConfig:
     source: str
 
 
+# Kep in sync with: .bcr/presubmit.yml, test/aspect/execute_tests.py, test/workspace_integration/test.py
 TOOLCHAINS = [
     ToolchainConfig(
         name="host_toolchain",
         source="https://github.com/bazelbuild/rules_cc",
-        bazel_versions=[BazelVersion("7.2.1"), BazelVersion("8.x"), BazelVersion("9.*")],
+        bazel_versions=[BazelVersion("7.2.1"), BazelVersion("8.x"), BazelVersion("9.*"), BazelVersion("rolling")],
         platforms=["Linux", "Darwin", "Windows"],
         extra_args=[],
         module_snippet="",

--- a/test/workspace_integration/test.py
+++ b/test/workspace_integration/test.py
@@ -19,12 +19,13 @@ from test.support.bazel import get_bazel_binary, get_explicit_bazel_version, mak
 logging.basicConfig(format="%(message)s", level=logging.INFO)
 log = logging.getLogger()
 
-# Kep in sync with: test/aspect/execute_tests.py, test/cc_toolchains/upstream/test.py, .bcr/presubmit.yml
+# Kep in sync with: .bcr/presubmit.yml, test/aspect/execute_tests.py, test/cc_toolchains/upstream/test.py
 BAZEL_VERSIONS_UNDER_TEST = [
     "7.2.1",
     "7.x",
     "8.x",
     "9.*",
+    "rolling",
 ]
 
 


### PR DESCRIPTION
This was not possible before due to the Bazel 10 rolling release being broken.