### PR TITLE
feat(aspect): Fix includes reporting in "no preprocessor" mode

### DIFF
--- a/dwyu/aspect/private/preprocessing/extract_includes.cpp
+++ b/dwyu/aspect/private/preprocessing/extract_includes.cpp
@@ -72,12 +72,14 @@ class IncludeStatementExtractor {
         }
 
         if (expect_quoting_or_white_space_ && (character == '"' || character == '<')) {
+            parsed_include_ += character;
             expect_quoting_or_white_space_ = false;
             expect_path_ = true;
             return;
         }
 
         if (expect_path_ && (character == '"' || character == '>')) {
+            parsed_include_ += character;
             ongoing_extraction_ = false;
             finished_extraction_ = true;
             return;

--- a/dwyu/aspect/private/preprocessing/test/data/commented_includes.h
+++ b/dwyu/aspect/private/preprocessing/test/data/commented_includes.h
@@ -12,9 +12,9 @@ void Foo(); // #include "commented.h"
 */
 #include "include_c.h"
 
-/* #include "commented.h" */ /**/ /**/ #include "include_d.h"
+/* #include "commented.h" */ /**/ /**/ #include<include_d.h>
 
-/*/* #include "commented.h" */ #include "include_e.h" /* #include "commented.h" */
+/*/* #include "commented.h" */ #include<include_e.h> /* #include "commented.h" */
 
 /*
 /*

--- a/dwyu/aspect/private/preprocessing/test/extract_includes_test.cpp
+++ b/dwyu/aspect/private/preprocessing/test/extract_includes_test.cpp
@@ -35,7 +35,7 @@ TEST(extractIncludes, ExtractIncludes) {
 
     const auto result = extractIncludes(text);
 
-    const std::set<std::string> expected = {"foo.h", "some/path.h", "no_extension"};
+    const std::set<std::string> expected = {"\"foo.h\"", "<some/path.h>", "<no_extension>"};
     EXPECT_EQ(result, expected);
 }
 
@@ -67,7 +67,7 @@ TEST(extractIncludes, IgnoreCommentedLines) {
 
     const auto result = extractIncludes(text);
 
-    const std::set<std::string> expected{"raff.h", "riff.h"};
+    const std::set<std::string> expected{"<raff.h>", "<riff.h>"};
     EXPECT_EQ(result, expected);
 }
 
@@ -89,7 +89,7 @@ TEST(extractIncludes, IgnoreCommentAfterRealInclude) {
 
     const auto result = extractIncludes(text);
 
-    const std::set<std::string> expected = {"foo.h"};
+    const std::set<std::string> expected = {"<foo.h>"};
     EXPECT_EQ(result, expected);
 }
 
@@ -99,7 +99,7 @@ TEST(extractIncludes, IgnoreCStyleCommentsInLineWithRealInclude) {
 
     const auto result = extractIncludes(text);
 
-    const std::set<std::string> expected = {"bar.h"};
+    const std::set<std::string> expected = {"<bar.h>"};
     EXPECT_EQ(result, expected);
 }
 
@@ -109,7 +109,7 @@ TEST(extractIncludes, CloseCStyleCommentNoMatterHowOftenOpened) {
 
     const auto result = extractIncludes(text);
 
-    const std::set<std::string> expected = {"bar.h"};
+    const std::set<std::string> expected = {"<bar.h>"};
     EXPECT_EQ(result, expected);
 }
 
@@ -120,7 +120,7 @@ TEST(extractIncludes, IgnoreCStyleCommentOpenendInCommentedLine) {
 
     const auto result = extractIncludes(text);
 
-    const std::set<std::string> expected = {"foo.h"};
+    const std::set<std::string> expected = {"<foo.h>"};
     EXPECT_EQ(result, expected);
 }
 
@@ -131,7 +131,8 @@ TEST(extractIncludes, FileWithComplexCases) {
     const auto result = extractIncludes(instream);
 
     const std::set<std::string> expected = {
-        "include_a.h", "include_b.h", "include_c.h", "include_d.h", "include_e.h", "include_f.h", "include_g.h",
+        "\"include_a.h\"", "\"include_b.h\"", "\"include_c.h\"", "<include_d.h>",
+        "<include_e.h>",   "\"include_f.h\"", "\"include_g.h\"",
     };
     EXPECT_EQ(result, expected);
 }


### PR DESCRIPTION
Before this change we ignores the quoting of an include. This was a problem because:
- Without the quotes the function to search for the files corresponding to an include statement is wrongly searching non system include paths for system includes (aka <..>)
- Inconsistent reporting of errors in the terminal