### PR TITLE
test(aspect): Use report files for evaluating integration tests

### DIFF
--- a/test/aspect/alias/test_invalid_dependency_through_alias.py
+++ b/test/aspect/alias/test_invalid_dependency_through_alias.py
@@ -1,6 +1,4 @@
-from pathlib import Path
-
-from expected_result import ExpectedResult
+from expected_result import ExpectedDwyuFailure, ExpectedFailure
 from test_case import TestCaseBase
 
 from test.support.result import Result
@@ -8,15 +6,10 @@ from test.support.result import Result
 
 class TestCase(TestCaseBase):
     def execute_test_logic(self) -> Result:
-        expected_invalid_includes = [
-            "In file 'alias/use_a_and_b.cpp' include: \"alias/a.h\""
-            if self._cpp_impl_based
-            else f"File='{Path('alias/use_a_and_b.cpp')}', include='alias/a.h'"
-        ]
-        expected = ExpectedResult(
-            success=False,
-            invalid_includes=expected_invalid_includes,
+        target = "//alias:use_a_transitively"
+        expected = ExpectedFailure(
+            ExpectedDwyuFailure(target=target, invalid_includes={"alias/use_a_and_b.cpp": ["alias/a.h"]})
         )
-        actual = self._run_dwyu(target="//alias:use_a_transitively", aspect=self.default_aspect)
+        actual = self._run_dwyu(target=target, aspect=self.default_aspect)
 
         return self._check_result(actual=actual, expected=expected)

--- a/test/aspect/alias/test_unused_dependency_through_alias.py
+++ b/test/aspect/alias/test_unused_dependency_through_alias.py
@@ -1,4 +1,4 @@
-from expected_result import ExpectedResult
+from expected_result import ExpectedDwyuFailure, ExpectedFailure
 from test_case import TestCaseBase
 
 from test.support.result import Result
@@ -6,7 +6,8 @@ from test.support.result import Result
 
 class TestCase(TestCaseBase):
     def execute_test_logic(self) -> Result:
-        expected = ExpectedResult(success=False, unused_public_deps=["//alias:lib_a"])
-        actual = self._run_dwyu(target="//alias:unused_dependency", aspect=self.default_aspect)
+        target = "//alias:unused_dependency"
+        expected = ExpectedFailure(ExpectedDwyuFailure(target=target, unused_public_deps=["//alias:lib_a"]))
+        actual = self._run_dwyu(target=target, aspect=self.default_aspect)
 
         return self._check_result(actual=actual, expected=expected)

--- a/test/aspect/alias/test_use_dependency_through_alias.py
+++ b/test/aspect/alias/test_use_dependency_through_alias.py
@@ -1,4 +1,4 @@
-from expected_result import ExpectedResult
+from expected_result import ExpectedSuccess
 from test_case import TestCaseBase
 
 from test.support.result import Result
@@ -6,7 +6,6 @@ from test.support.result import Result
 
 class TestCase(TestCaseBase):
     def execute_test_logic(self) -> Result:
-        expected = ExpectedResult(success=True)
         actual = self._run_dwyu(target="//alias:use_a_directly", aspect=self.default_aspect)
 
-        return self._check_result(actual=actual, expected=expected)
+        return self._check_result(actual=actual, expected=ExpectedSuccess())

--- a/test/aspect/command_length_limit/test_command_length_limit.py
+++ b/test/aspect/command_length_limit/test_command_length_limit.py
@@ -1,4 +1,4 @@
-from expected_result import ExpectedResult
+from expected_result import ExpectedSuccess
 from test_case import TestCaseBase
 
 from test.support.result import Result
@@ -6,7 +6,6 @@ from test.support.result import Result
 
 class TestCase(TestCaseBase):
     def execute_test_logic(self) -> Result:
-        expected = ExpectedResult(success=True)
         actual = self._run_dwyu(target="//command_length_limit:many_defines", aspect=self.default_aspect)
 
-        return self._check_result(actual=actual, expected=expected)
+        return self._check_result(actual=actual, expected=ExpectedSuccess())

--- a/test/aspect/complex_includes/test_complex_includes.py
+++ b/test/aspect/complex_includes/test_complex_includes.py
@@ -1,4 +1,4 @@
-from expected_result import ExpectedResult
+from expected_result import ExpectedSuccess
 from test_case import TestCaseBase
 
 from test.support.result import Result
@@ -11,10 +11,9 @@ class TestCase(TestCaseBase):
         working inside the own workspace. Thus, we explicitly test working in an external workspace on top of normal
         targets from within the main workspace.
         """
-        expected = ExpectedResult(success=True)
         actual = self._run_dwyu(
             target=["//complex_includes:all", "@complex_includes_test_repo//..."],
             aspect=self.default_aspect,
         )
 
-        return self._check_result(actual=actual, expected=expected)
+        return self._check_result(actual=actual, expected=ExpectedSuccess())

--- a/test/aspect/complex_includes/test_feature_external_include_paths.py
+++ b/test/aspect/complex_includes/test_feature_external_include_paths.py
@@ -1,4 +1,4 @@
-from expected_result import ExpectedResult
+from expected_result import ExpectedSuccess
 from test_case import TestCaseBase
 
 from test.support.result import Result
@@ -11,11 +11,10 @@ class TestCase(TestCaseBase):
         CompilationContext to the 'external_includes' list so they can be provided to the compiler via '-isystem'.
         This allows silencing compiler warnings originating from those external headers.
         """
-        expected = ExpectedResult(success=True)
         actual = self._run_dwyu(
             target=["//complex_includes:all", "@complex_includes_test_repo//..."],
             extra_args=["--features=external_include_paths"],
             aspect=self.default_aspect,
         )
 
-        return self._check_result(actual=actual, expected=expected)
+        return self._check_result(actual=actual, expected=ExpectedSuccess())

--- a/test/aspect/defines/test_command_line_defines.py
+++ b/test/aspect/defines/test_command_line_defines.py
@@ -1,6 +1,6 @@
 from platform import system
 
-from expected_result import ExpectedResult
+from expected_result import ExpectedSuccess
 from test_case import TestCaseBase
 
 from test.support.result import Result
@@ -16,11 +16,10 @@ def make_define(flag: str) -> str:
 
 class TestCase(TestCaseBase):
     def execute_test_logic(self) -> Result:
-        expected = ExpectedResult(success=True)
         actual = self._run_dwyu(
             target="//defines:use_command_line_defines",
             aspect=self.default_aspect,
             extra_args=[f"--cxxopt={make_define('SOME_FLAG')}", f"--cxxopt={make_define('SOME_VALUE=42')}"],
         )
 
-        return self._check_result(actual=actual, expected=expected)
+        return self._check_result(actual=actual, expected=ExpectedSuccess())

--- a/test/aspect/defines/test_processing_defines.py
+++ b/test/aspect/defines/test_processing_defines.py
@@ -1,4 +1,4 @@
-from expected_result import ExpectedResult
+from expected_result import ExpectedSuccess
 from test_case import TestCaseBase
 
 from test.support.result import Result
@@ -6,7 +6,6 @@ from test.support.result import Result
 
 class TestCase(TestCaseBase):
     def execute_test_logic(self) -> Result:
-        expected = ExpectedResult(success=True)
         actual = self._run_dwyu(target="//defines:all", aspect=self.default_aspect)
 
-        return self._check_result(actual=actual, expected=expected)
+        return self._check_result(actual=actual, expected=ExpectedSuccess())

--- a/test/aspect/duplicate_includes/test_duplicate_includes_failure.py
+++ b/test/aspect/duplicate_includes/test_duplicate_includes_failure.py
@@ -1,6 +1,4 @@
-from pathlib import Path
-
-from expected_result import ExpectedResult
+from expected_result import ExpectedDwyuFailure, ExpectedFailure
 from test_case import TestCaseBase
 
 from test.support.result import Result
@@ -12,16 +10,14 @@ class TestCase(TestCaseBase):
         We are not interested in those really appearing 2 times. We simply want to make sure that the same include statement
         appearing multiple times is not causing some undesired behavior during the analysis.
         """
-        expected_invalid_includes = (
-            [
-                "In file 'duplicate_includes/use_foo.h' include: \"duplicate_includes/foo.h\"",
-                "In file 'duplicate_includes/use_foo.h' include: \"duplicate_includes/foo.h\"",
-            ]
-            if self._cpp_impl_based
-            else [f"File='{Path('duplicate_includes/use_foo.h')}', include='duplicate_includes/foo.h'"]
-        )
 
-        expected = ExpectedResult(success=False, invalid_includes=expected_invalid_includes)
-        actual = self._run_dwyu(target="//duplicate_includes:use_foo_transitively", aspect=self.default_aspect)
+        target = "//duplicate_includes:use_foo_transitively"
+        expected_invalid_includes = (
+            {"duplicate_includes/use_foo.h": ["duplicate_includes/foo.h", "duplicate_includes/foo.h"]}
+            if self._cpp_impl_based
+            else {"duplicate_includes/use_foo.h": ["duplicate_includes/foo.h"]}
+        )
+        expected = ExpectedFailure(ExpectedDwyuFailure(target=target, invalid_includes=expected_invalid_includes))
+        actual = self._run_dwyu(target=target, aspect=self.default_aspect)
 
         return self._check_result(actual=actual, expected=expected)

--- a/test/aspect/duplicate_includes/test_duplicate_includes_success.py
+++ b/test/aspect/duplicate_includes/test_duplicate_includes_success.py
@@ -1,4 +1,4 @@
-from expected_result import ExpectedResult
+from expected_result import ExpectedSuccess
 from test_case import TestCaseBase
 
 from test.support.result import Result
@@ -6,7 +6,6 @@ from test.support.result import Result
 
 class TestCase(TestCaseBase):
     def execute_test_logic(self) -> Result:
-        expected = ExpectedResult(success=True)
         actual = self._run_dwyu(target="//duplicate_includes:use_foo", aspect=self.default_aspect)
 
-        return self._check_result(actual=actual, expected=expected)
+        return self._check_result(actual=actual, expected=ExpectedSuccess())

--- a/test/aspect/expected_result.py
+++ b/test/aspect/expected_result.py
@@ -1,17 +1,68 @@
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
 
-# Each line in the output corresponding to an error is expected to start with this
-ERRORS_PREFIX = " " * 2
+from test.support.result import Error, Result, Success
 
-# DWYU terminal output key fragments
 DWYU_FAILURE = "Result: FAILURE"
-CATEGORY_INVALID_INCLUDES = "Includes which are not available from the direct dependencies"
-CATEGORY_NON_PRIVATE_DEPS = "deps' which should be moved to 'implementation_deps'"
-CATEGORY_NON_PRIVATE_DEPS_LEGACY = "Public dependencies which are used only in private code"
-CATEGORY_UNUSED_PUBLIC_DEPS = "Unused dependencies in 'deps'"
-CATEGORY_UNUSED_PRIVATE_DEPS = "Unused dependencies in 'implementation_deps'"
+DWYU_REPORT = "DWYU Report:"
+
+
+def normalize_file_path(path: str) -> str:
+    """
+    On Windows DWYU reports Windows file paths with backslashes, but our tests expect POSIX-style paths with forward slashes.
+    """
+    # Remove the double baskslash replacing after the Python impl has been removed
+    return path.replace("\\\\", "/").replace("\\", "/")
+
+
+def normalize_file_paths(paths: Iterable[str]) -> list[str]:
+    return [normalize_file_path(p) for p in paths]
+
+
+def normalize_target_name(target: str) -> str:
+    """
+    For ease of use in test specs we desire the short apparent name style instead of the canonical Bazel target names.
+    """
+    return target.replace("@@", "@").replace("@//", "//")
+
+
+def normalize_target_names(target: Iterable[str]) -> list[str]:
+    return [normalize_target_name(t) for t in target]
+
+
+@dataclass
+class ExpectedDwyuFailure:
+    target: str
+    invalid_includes: dict[str, list[str]] = field(default_factory=dict)
+    unused_public_deps: list[str] = field(default_factory=list)
+    unused_private_deps: list[str] = field(default_factory=list)
+    deps_which_should_be_private: list[str] = field(default_factory=list)
+
+    def check_expectation(self, report_data: dict) -> bool:
+        reported_public_includes_without_dep = report_data.get("public_includes_without_dep", {})
+        reported_private_includes_without_dep = report_data.get("private_includes_without_dep", {})
+        reported_invalid_includes = {**reported_public_includes_without_dep, **reported_private_includes_without_dep}
+        if set(normalize_file_paths(reported_invalid_includes.keys())) != set(self.invalid_includes.keys()):
+            return False
+        for src_file, includes in reported_invalid_includes.items():
+            if set(self.invalid_includes.get(normalize_file_path(src_file), [])) != set(includes):
+                return False
+
+        if set(self.unused_public_deps) != set(normalize_target_names(report_data.get("unused_deps", []))):
+            return False
+
+        if set(self.unused_private_deps) != set(
+            normalize_target_names(report_data.get("unused_implementation_deps", []))
+        ):
+            return False
+
+        return set(self.deps_which_should_be_private) == set(
+            normalize_target_names(report_data.get("deps_which_should_be_private", []))
+        )
 
 
 @dataclass
@@ -21,83 +72,53 @@ class ExpectedResult:
     to compare a given output to the expectations.
     """
 
-    success: bool
-    invalid_includes: list[str] = field(default_factory=list)
-    unused_public_deps: list[str] = field(default_factory=list)
-    unused_private_deps: list[str] = field(default_factory=list)
-    deps_which_should_be_private: list[str] = field(default_factory=list)
+    def __init__(self, success: bool, failures: list[ExpectedDwyuFailure]) -> None:
+        self.failures = failures if failures else []
+        self.success = success
 
-    def matches_expectation(self, return_code: int, dwyu_output: str, is_cpp_impl: bool) -> bool:
+    def matches_expectation(self, return_code: int, dwyu_output: str, reports_root: Path) -> Result:  # noqa: PLR0911
         if not self._has_correct_status(return_code=return_code, output=dwyu_output):
-            return False
+            return Error("unexpected DWYU status code")
 
-        output_lines = dwyu_output.split("\n")
-        if not ExpectedResult._has_expected_errors(
-            expected_errors=self.invalid_includes,
-            error_category=CATEGORY_INVALID_INCLUDES,
-            output=output_lines,
-        ):
-            return False
-        if not ExpectedResult._has_expected_errors(
-            expected_errors=self.unused_public_deps,
-            error_category=CATEGORY_UNUSED_PUBLIC_DEPS,
-            output=output_lines,
-        ):
-            return False
-        if not ExpectedResult._has_expected_errors(
-            expected_errors=self.unused_private_deps,
-            error_category=CATEGORY_UNUSED_PRIVATE_DEPS,
-            output=output_lines,
-        ):
-            return False
-        if not ExpectedResult._has_expected_errors(  # noqa: SIM103
-            expected_errors=self.deps_which_should_be_private,
-            error_category=CATEGORY_NON_PRIVATE_DEPS if is_cpp_impl else CATEGORY_NON_PRIVATE_DEPS_LEGACY,
-            output=output_lines,
-        ):
-            return False
+        if self.success:
+            # No further checks needed for successful runs
+            return Success()
 
-        return True
+        all_report_paths = [
+            line.split(DWYU_REPORT)[1].strip() for line in dwyu_output.splitlines() if DWYU_REPORT in line
+        ]
+        all_reports = {}
+        for report in all_report_paths:
+            report_file = reports_root / report
+            if not report_file.exists():
+                return Error(f"missing DWYU report file: {report_file}")
+            data = json.loads(report_file.read_text())
+            all_reports[normalize_target_name(data["analyzed_target"])] = data
+
+        if len(self.failures) != len(all_report_paths):
+            return Error("number of DWYU reports does not match expected failures")
+
+        for expected_failure in self.failures:
+            expected_target = normalize_target_name(expected_failure.target)
+            if expected_target not in all_reports:
+                return Error("missing report for expected failure")
+            if not expected_failure.check_expectation(all_reports[expected_target]):
+                return Error("found unexpected DWYU results")
+
+        return Success()
 
     def _has_correct_status(self, return_code: int, output: str) -> bool:
         if self.success and return_code == 0:
             return True
+        # Ensuring 'DWYU_FAILURE' is in the output prevents overlooking failure due to unrelated issues
         return not self.success and return_code != 0 and DWYU_FAILURE in output
 
-    @staticmethod
-    def _get_error_lines(idx_category: int, output: list[str]) -> list[str]:
-        errors_begin = idx_category + 1
-        errors_end = 0
-        for i in range(errors_begin, len(output)):
-            if output[i].startswith(ERRORS_PREFIX):
-                errors_end = i + 1
-            else:
-                break
-        return output[errors_begin:errors_end]
 
-    @staticmethod
-    def _has_expected_errors(expected_errors: list[str], error_category: str, output: list[str]) -> bool:
-        if not expected_errors:
-            return True
+class ExpectedSuccess(ExpectedResult):
+    def __init__(self) -> None:
+        super().__init__(success=True, failures=[])
 
-        idx_category = ExpectedResult._find_line_with(lines=output, val=error_category)
-        if idx_category is None:
-            return False
 
-        return ExpectedResult._has_errors(
-            error_lines=ExpectedResult._get_error_lines(idx_category=idx_category, output=output),
-            expected_errors=expected_errors,
-        )
-
-    @staticmethod
-    def _find_line_with(lines: list[str], val: str) -> int | None:
-        for idx, line in enumerate(lines):
-            if val in line:
-                return idx
-        return None
-
-    @staticmethod
-    def _has_errors(error_lines: list[str], expected_errors: list[str]) -> bool:
-        if len(error_lines) != len(expected_errors):
-            return False
-        return all(any(error in line for line in error_lines) for error in expected_errors)
+class ExpectedFailure(ExpectedResult):
+    def __init__(self, failures: ExpectedDwyuFailure | list[ExpectedDwyuFailure]) -> None:
+        super().__init__(success=False, failures=[failures] if isinstance(failures, ExpectedDwyuFailure) else failures)

--- a/test/aspect/expected_result_test.py
+++ b/test/aspect/expected_result_test.py
@@ -1,192 +1,210 @@
 from __future__ import annotations
 
+import json
 import unittest
+from pathlib import Path
 
-from expected_result import (
-    CATEGORY_INVALID_INCLUDES,
-    CATEGORY_NON_PRIVATE_DEPS,
-    CATEGORY_NON_PRIVATE_DEPS_LEGACY,
-    CATEGORY_UNUSED_PRIVATE_DEPS,
-    CATEGORY_UNUSED_PUBLIC_DEPS,
-    DWYU_FAILURE,
-    ERRORS_PREFIX,
-    ExpectedResult,
-)
+from expected_result import DWYU_FAILURE, DWYU_REPORT, ExpectedDwyuFailure, ExpectedFailure, ExpectedSuccess
 
 from test.support.result import Error, Success
 
 
-class TestExpectedResult(unittest.TestCase):
-    @staticmethod
-    def _make_error_output(category: str, errors: list[str]) -> str:
-        msg = DWYU_FAILURE + "\n"
-        msg += category + "\n"
-        msg += "\n".join(f"{ERRORS_PREFIX}{err}" for err in errors)
-        return msg
+def make_failure(
+    target: str = "//:foo:bar",
+    invalid_includes: dict[str, list[str]] | None = None,
+    unused_public_deps: list[str] | None = None,
+    unused_private_deps: list[str] | None = None,
+    deps_which_should_be_private: list[str] | None = None,
+) -> ExpectedDwyuFailure:
+    return ExpectedDwyuFailure(
+        target=target,
+        invalid_includes=invalid_includes if invalid_includes is not None else {},
+        unused_public_deps=unused_public_deps if unused_public_deps is not None else [],
+        unused_private_deps=unused_private_deps if unused_private_deps is not None else [],
+        deps_which_should_be_private=deps_which_should_be_private if deps_which_should_be_private is not None else [],
+    )
 
-    def test_expected_success_ok(self) -> None:
-        unit = ExpectedResult(success=True)
-        self.assertTrue(unit.matches_expectation(return_code=0, dwyu_output="", is_cpp_impl=False))
 
-    def test_expected_success_error(self) -> None:
-        unit = ExpectedResult(success=True)
-        self.assertFalse(unit.matches_expectation(return_code=1, dwyu_output="", is_cpp_impl=False))
+def make_report_data(
+    analyzed_target: str = "//:foo:bar",
+    invalid_pub_includes: dict[str, list[str]] | None = None,
+    invalid_priv_includes: dict[str, list[str]] | None = None,
+    unused_deps: list[str] | None = None,
+    unused_impl_deps: list[str] | None = None,
+    deps_which_should_be_private: list[str] | None = None,
+) -> dict:
+    return {
+        "analyzed_target": analyzed_target,
+        "public_includes_without_dep": invalid_pub_includes if invalid_pub_includes is not None else {},
+        "private_includes_without_dep": invalid_priv_includes if invalid_priv_includes is not None else {},
+        "unused_deps": unused_deps if unused_deps is not None else [],
+        "unused_implementation_deps": unused_impl_deps if unused_impl_deps is not None else [],
+        "deps_which_should_be_private": deps_which_should_be_private
+        if deps_which_should_be_private is not None
+        else [],
+    }
 
-    def test_expected_failure_ok(self) -> None:
-        unit = ExpectedResult(success=False)
-        self.assertTrue(unit.matches_expectation(return_code=1, dwyu_output=DWYU_FAILURE, is_cpp_impl=False))
 
-    def test_expected_failure_error(self) -> None:
-        unit = ExpectedResult(success=False)
-        self.assertFalse(unit.matches_expectation(return_code=0, dwyu_output="", is_cpp_impl=False))
+class ExpectedDwyuFailureTest(unittest.TestCase):
+    def test_check_expectation_for_no_expected_error(self) -> None:
+        unit = make_failure()
+        self.assertTrue(unit.check_expectation(make_report_data()))
 
-    def test_expected_failure_error_due_to_missing_output(self) -> None:
-        unit = ExpectedResult(success=False)
-        self.assertFalse(unit.matches_expectation(return_code=1, dwyu_output="", is_cpp_impl=False))
-
-    def test_expected_fail_due_to_invalid_includes(self) -> None:
-        unit = ExpectedResult(success=False, invalid_includes=["foo/bar.cpp", "bar/foo.h"])
+    def test_check_expectation_for_expected_invalid_includes(self) -> None:
+        unit = make_failure(
+            invalid_includes={
+                "priv.cpp": ["priv/some/header.h", "priv/other/header.h"],
+                "pub.h": ["pub/some/header.h", "pub/other/header.h"],
+            }
+        )
         self.assertTrue(
-            unit.matches_expectation(
-                return_code=1,
-                dwyu_output=self._make_error_output(
-                    category=CATEGORY_INVALID_INCLUDES, errors=["foo/bar.cpp", "bar/foo.h"]
-                ),
-                is_cpp_impl=False,
-            )
-        )
-
-    def test_expected_fail_due_to_invalid_includes_fails(self) -> None:
-        unit = ExpectedResult(success=False, invalid_includes=["foo/bar.cpp", "bar/foo.h"])
-        self.assertFalse(
-            unit.matches_expectation(
-                return_code=1,
-                dwyu_output=self._make_error_output(category=CATEGORY_INVALID_INCLUDES, errors=["foo/bar.cpp"]),
-                is_cpp_impl=False,
-            )
-        )
-
-    def test_expected_fail_due_to_invalid_includes_fails_on_other_error(self) -> None:
-        unit = ExpectedResult(success=False, invalid_includes=["foo/bar.cpp", "bar/foo.h"])
-        for cat in [CATEGORY_NON_PRIVATE_DEPS, CATEGORY_UNUSED_PUBLIC_DEPS, CATEGORY_UNUSED_PRIVATE_DEPS]:
-            self.assertFalse(
-                unit.matches_expectation(
-                    return_code=1,
-                    dwyu_output=self._make_error_output(category=cat, errors=["foo/bar.cpp", "bar/foo.h"]),
-                    is_cpp_impl=False,
+            unit.check_expectation(
+                make_report_data(
+                    invalid_pub_includes={"pub.h": ["pub/other/header.h", "pub/some/header.h"]},
+                    invalid_priv_includes={"priv.cpp": ["priv/other/header.h", "priv/some/header.h"]},
                 )
             )
+        )
 
-    def test_expected_fail_due_to_unused_public_deps(self) -> None:
-        unit = ExpectedResult(success=False, unused_public_deps=["//foo:bar", "//bar:foo"])
+    def test_check_expectation_for_unexpected_invalid_includes_src_file(self) -> None:
+        unit = make_failure(invalid_includes={"foo.h": ["some/header.h"]})
+        self.assertFalse(unit.check_expectation(make_report_data(invalid_pub_includes={"bar.h": ["some/header.h"]})))
+
+    def test_check_expectation_for_unexpected_invalid_includes_include(self) -> None:
+        unit = make_failure(invalid_includes={"foo.cpp": ["some.h"]})
+        self.assertFalse(unit.check_expectation(make_report_data(invalid_priv_includes={"foo.cpp": ["other.h"]})))
+
+    def test_check_expectation_for_expected_unused_deps(self) -> None:
+        unit = make_failure(unused_public_deps=["//riff:raff"])
+        self.assertTrue(unit.check_expectation(make_report_data(unused_deps=["//riff:raff"])))
+
+    def test_check_expectation_for_unexpected_unused_deps(self) -> None:
+        unit = make_failure(unused_public_deps=["//riff:raff"])
+        self.assertFalse(unit.check_expectation(make_report_data(unused_deps=["//unexpected:dep"])))
+
+    def test_check_expectation_for_expected_unused_implementation_deps(self) -> None:
+        unit = make_failure(unused_private_deps=["//riff:raff"])
+        self.assertTrue(unit.check_expectation(make_report_data(unused_impl_deps=["//riff:raff"])))
+
+    def test_check_expectation_for_unexpected_unused_implementation_deps(self) -> None:
+        unit = make_failure(unused_private_deps=["//riff:raff"])
+        self.assertFalse(unit.check_expectation(make_report_data(unused_impl_deps=["//unexpected:dep"])))
+
+    def test_check_expectation_for_expected_deps_which_should_be_private(self) -> None:
+        unit = make_failure(deps_which_should_be_private=["//riff:raff"])
+        self.assertTrue(unit.check_expectation(make_report_data(deps_which_should_be_private=["//riff:raff"])))
+
+    def test_check_expectation_for_unexpected_deps_which_should_be_private(self) -> None:
+        unit = make_failure(deps_which_should_be_private=["//riff:raff"])
+        self.assertFalse(unit.check_expectation(make_report_data(deps_which_should_be_private=["//unexpected:dep"])))
+
+    def test_check_expectation_normalizes_labels(self) -> None:
+        unit = make_failure(
+            unused_public_deps=["//:foo", "//:bar"],
+            unused_private_deps=["@riff//:raff"],
+            deps_which_should_be_private=["//:baz"],
+        )
         self.assertTrue(
-            unit.matches_expectation(
-                return_code=1,
-                dwyu_output=self._make_error_output(
-                    category=CATEGORY_UNUSED_PUBLIC_DEPS, errors=["//foo:bar", "//bar:foo"]
-                ),
-                is_cpp_impl=False,
-            )
-        )
-
-    def test_expected_fail_due_to_unused_public_deps_fails(self) -> None:
-        unit = ExpectedResult(success=False, unused_public_deps=["//foo:bar", "//bar:foo"])
-        self.assertFalse(
-            unit.matches_expectation(
-                return_code=1,
-                dwyu_output=self._make_error_output(category=CATEGORY_UNUSED_PUBLIC_DEPS, errors=["//foo:bar"]),
-                is_cpp_impl=False,
-            )
-        )
-
-    def test_expected_fail_due_to_unused_public_deps_fails_on_other_error(self) -> None:
-        unit = ExpectedResult(success=False, unused_public_deps=["//foo:bar", "//bar:foo"])
-        for cat in [CATEGORY_INVALID_INCLUDES, CATEGORY_NON_PRIVATE_DEPS, CATEGORY_UNUSED_PRIVATE_DEPS]:
-            self.assertFalse(
-                unit.matches_expectation(
-                    return_code=1,
-                    dwyu_output=self._make_error_output(category=cat, errors=["//foo:bar", "//bar:foo"]),
-                    is_cpp_impl=False,
+            unit.check_expectation(
+                make_report_data(
+                    unused_deps=["@@//:foo", "@//:bar"],
+                    unused_impl_deps=["@@riff//:raff"],
+                    deps_which_should_be_private=["@//:baz"],
                 )
             )
-
-    def test_expected_fail_due_to_unused_private_deps(self) -> None:
-        unit = ExpectedResult(success=False, unused_private_deps=["//foo:bar", "//bar:foo"])
-        self.assertTrue(
-            unit.matches_expectation(
-                return_code=1,
-                dwyu_output=self._make_error_output(
-                    category=CATEGORY_UNUSED_PRIVATE_DEPS, errors=["//foo:bar", "//bar:foo"]
-                ),
-                is_cpp_impl=False,
-            )
         )
 
-    def test_expected_fail_due_to_unused_private_deps_fails(self) -> None:
-        unit = ExpectedResult(success=False, unused_private_deps=["//foo:bar", "//bar:foo"])
-        self.assertFalse(
-            unit.matches_expectation(
-                return_code=1,
-                dwyu_output=self._make_error_output(category=CATEGORY_UNUSED_PRIVATE_DEPS, errors=["//foo:bar"]),
-                is_cpp_impl=False,
-            )
+    def test_check_expectation_normalizes_paths_for_windows(self) -> None:
+        unit = make_failure(invalid_includes={"foo/bar.h": ["header.h"]})
+        self.assertTrue(unit.check_expectation(make_report_data(invalid_pub_includes={r"foo\bar.h": ["header.h"]})))
+        self.assertTrue(unit.check_expectation(make_report_data(invalid_pub_includes={r"foo\\bar.h": ["header.h"]})))
+
+
+class ExpectedResultTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.reports = Path("reports")
+
+    def _make_report_(self, name: str, data: dict) -> None:
+        report = self.reports / name
+        report.parent.mkdir(parents=True, exist_ok=True)
+        report.write_text(json.dumps(data))
+
+    def test_for_expected_success(self) -> None:
+        unit = ExpectedSuccess()
+
+        result = unit.matches_expectation(return_code=0, dwyu_output="", reports_root=self.reports)
+
+        self.assertTrue(result.is_success())
+
+    def test_fail_for_unexpected_failure(self) -> None:
+        unit = ExpectedSuccess()
+
+        result = unit.matches_expectation(return_code=1, dwyu_output="", reports_root=self.reports)
+
+        self.assertFalse(result.is_success())
+        self.assertEqual(result.error, "unexpected DWYU status code")
+
+    def test_fail_for_unexpected_success(self) -> None:
+        unit = ExpectedFailure([])
+
+        result = unit.matches_expectation(return_code=0, dwyu_output="", reports_root=self.reports)
+
+        self.assertFalse(result.is_success())
+        self.assertEqual(result.error, "unexpected DWYU status code")
+
+    def test_fail_for_failure_without_dwyu_error(self) -> None:
+        unit = ExpectedFailure([])
+
+        result = unit.matches_expectation(return_code=1, dwyu_output="", reports_root=self.reports)
+
+        self.assertFalse(result.is_success())
+        self.assertEqual(result.error, "unexpected DWYU status code")
+
+    def test_fail_for_missing_dwyu_report(self) -> None:
+        unit = ExpectedFailure(make_failure(target="//:foo"))
+        # No report created
+
+        result = unit.matches_expectation(
+            return_code=1, dwyu_output=f"{DWYU_FAILURE}\n{DWYU_REPORT} foo.json", reports_root=self.reports
         )
 
-    def test_expected_fail_due_to_unused_private_deps_fails_on_other_error(self) -> None:
-        unit = ExpectedResult(success=False, unused_private_deps=["//foo:bar", "//bar:foo"])
-        for cat in [CATEGORY_INVALID_INCLUDES, CATEGORY_NON_PRIVATE_DEPS, CATEGORY_UNUSED_PUBLIC_DEPS]:
-            self.assertFalse(
-                unit.matches_expectation(
-                    return_code=1,
-                    dwyu_output=self._make_error_output(category=cat, errors=["//foo:bar", "//bar:foo"]),
-                    is_cpp_impl=False,
-                )
-            )
+        self.assertFalse(result.is_success())
+        self.assertEqual(result.error, "missing DWYU report file: reports/foo.json")
 
-    def test_expected_fail_due_to_non_private_deps(self) -> None:
-        unit = ExpectedResult(success=False, deps_which_should_be_private=["//foo:bar", "//bar:foo"])
-        self.assertTrue(
-            unit.matches_expectation(
-                return_code=1,
-                dwyu_output=self._make_error_output(
-                    category=CATEGORY_NON_PRIVATE_DEPS, errors=["//foo:bar", "//bar:foo"]
-                ),
-                is_cpp_impl=True,
-            )
+    def test_fail_for_wrong_number_of_dwyu_reports(self) -> None:
+        unit = ExpectedFailure([])
+        self._make_report_(name="foo.json", data=make_report_data())
+
+        result = unit.matches_expectation(
+            return_code=1, dwyu_output=f"{DWYU_FAILURE}\n{DWYU_REPORT} foo.json", reports_root=self.reports
         )
 
-    def test_expected_fail_due_to_non_private_deps_legacy(self) -> None:
-        unit = ExpectedResult(success=False, deps_which_should_be_private=["//foo:bar", "//bar:foo"])
-        self.assertTrue(
-            unit.matches_expectation(
-                return_code=1,
-                dwyu_output=self._make_error_output(
-                    category=CATEGORY_NON_PRIVATE_DEPS_LEGACY, errors=["//foo:bar", "//bar:foo"]
-                ),
-                is_cpp_impl=False,
-            )
+        self.assertFalse(result.is_success())
+        self.assertEqual(result.error, "number of DWYU reports does not match expected failures")
+
+    def test_fail_for_unexpected_dwyu_report(self) -> None:
+        unit = ExpectedFailure(make_failure(target="//:bar"))
+        self._make_report_(name="foo.json", data=make_report_data())
+
+        result = unit.matches_expectation(
+            return_code=1, dwyu_output=f"{DWYU_FAILURE}\n{DWYU_REPORT} foo.json", reports_root=self.reports
         )
 
-    def test_expected_fail_due_to_non_private_deps_fails(self) -> None:
-        unit = ExpectedResult(success=False, deps_which_should_be_private=["//foo:bar", "//bar:foo"])
-        self.assertFalse(
-            unit.matches_expectation(
-                return_code=1,
-                dwyu_output=self._make_error_output(category=CATEGORY_NON_PRIVATE_DEPS, errors=["//foo:bar"]),
-                is_cpp_impl=True,
-            )
+        self.assertFalse(result.is_success())
+        self.assertEqual(result.error, "missing report for expected failure")
+
+    def test_fail_for_unexpected_reported_error(self) -> None:
+        unit = ExpectedFailure(make_failure(target="//:foo", unused_public_deps=["//:bar"]))
+        self._make_report_(
+            name="foo.json", data=make_report_data(analyzed_target="//:foo", unused_deps=["//:unexpected"])
         )
 
-    def test_expected_fail_due_to_non_private_deps_fails_on_other_error(self) -> None:
-        unit = ExpectedResult(success=False, deps_which_should_be_private=["//foo:bar", "//bar:foo"])
-        for cat in [CATEGORY_INVALID_INCLUDES, CATEGORY_UNUSED_PUBLIC_DEPS, CATEGORY_UNUSED_PRIVATE_DEPS]:
-            self.assertFalse(
-                unit.matches_expectation(
-                    return_code=1,
-                    dwyu_output=self._make_error_output(category=cat, errors=["//foo:bar", "//bar:foo"]),
-                    is_cpp_impl=False,
-                )
-            )
+        result = unit.matches_expectation(
+            return_code=1, dwyu_output=f"{DWYU_FAILURE}\n{DWYU_REPORT} foo.json", reports_root=self.reports
+        )
+
+        self.assertFalse(result.is_success())
+        self.assertEqual(result.error, "found unexpected DWYU results")
 
 
 class TestResult(unittest.TestCase):

--- a/test/aspect/external_repo/test_external_dependencies.py
+++ b/test/aspect/external_repo/test_external_dependencies.py
@@ -1,4 +1,4 @@
-from expected_result import ExpectedResult
+from expected_result import ExpectedSuccess
 from test_case import TestCaseBase
 
 from test.support.result import Result
@@ -11,7 +11,6 @@ class TestCase(TestCaseBase):
         working inside the own workspace. This test shows DWYU can be invoked on targets using libraries from external
         workspaces without failing unexpectedly.
         """
-        expected = ExpectedResult(success=True)
         actual = self._run_dwyu(target="//external_repo:use_external_libs", aspect=self.default_aspect)
 
-        return self._check_result(actual=actual, expected=expected)
+        return self._check_result(actual=actual, expected=ExpectedSuccess())

--- a/test/aspect/generated_code/test_generated_code.py
+++ b/test/aspect/generated_code/test_generated_code.py
@@ -1,4 +1,4 @@
-from expected_result import ExpectedResult
+from expected_result import ExpectedSuccess
 from test_case import TestCaseBase
 
 from test.support.result import Result
@@ -9,7 +9,6 @@ class TestCase(TestCaseBase):
         """
         Show that the aspect properly processes generated code which lives only in the bazel output tree.
         """
-        expected = ExpectedResult(success=True)
         actual = self._run_dwyu(target="//generated_code:foo", aspect=self.default_aspect)
 
-        return self._check_result(actual=actual, expected=expected)
+        return self._check_result(actual=actual, expected=ExpectedSuccess())

--- a/test/aspect/ignore_includes/test_custom_ignore_include_paths.py
+++ b/test/aspect/ignore_includes/test_custom_ignore_include_paths.py
@@ -1,4 +1,4 @@
-from expected_result import ExpectedResult
+from expected_result import ExpectedSuccess
 from test_case import TestCaseBase
 
 from test.support.result import Result
@@ -6,10 +6,9 @@ from test.support.result import Result
 
 class TestCase(TestCaseBase):
     def execute_test_logic(self) -> Result:
-        expected = ExpectedResult(success=True)
         actual = self._run_dwyu(
             target="//ignore_includes:use_multiple_ignored_headers",
             aspect=self.choose_aspect("//ignore_includes:aspect.bzl%ignore_include_paths_aspect"),
         )
 
-        return self._check_result(actual=actual, expected=expected)
+        return self._check_result(actual=actual, expected=ExpectedSuccess())

--- a/test/aspect/ignore_includes/test_extra_ignore_include_paths.py
+++ b/test/aspect/ignore_includes/test_extra_ignore_include_paths.py
@@ -1,4 +1,4 @@
-from expected_result import ExpectedResult
+from expected_result import ExpectedSuccess
 from test_case import TestCaseBase
 
 from test.support.result import Result
@@ -6,10 +6,9 @@ from test.support.result import Result
 
 class TestCase(TestCaseBase):
     def execute_test_logic(self) -> Result:
-        expected = ExpectedResult(success=True)
         actual = self._run_dwyu(
             target="//ignore_includes:use_ignored_header_and_std_lib",
             aspect=self.choose_aspect("//ignore_includes:aspect.bzl%extra_ignore_include_paths_aspect"),
         )
 
-        return self._check_result(actual=actual, expected=expected)
+        return self._check_result(actual=actual, expected=ExpectedSuccess())

--- a/test/aspect/ignore_includes/test_ignore_include_patterns.py
+++ b/test/aspect/ignore_includes/test_ignore_include_patterns.py
@@ -1,4 +1,4 @@
-from expected_result import ExpectedResult
+from expected_result import ExpectedSuccess
 from test_case import TestCaseBase
 
 from test.support.result import Result
@@ -6,10 +6,9 @@ from test.support.result import Result
 
 class TestCase(TestCaseBase):
     def execute_test_logic(self) -> Result:
-        expected = ExpectedResult(success=True)
         actual = self._run_dwyu(
             target="//ignore_includes:use_ignored_patterns",
             aspect=self.choose_aspect("//ignore_includes:aspect.bzl%extra_ignore_include_patterns_aspect"),
         )
 
-        return self._check_result(actual=actual, expected=expected)
+        return self._check_result(actual=actual, expected=ExpectedSuccess())

--- a/test/aspect/ignore_includes/test_include_not_covered_by_patterns.py
+++ b/test/aspect/ignore_includes/test_include_not_covered_by_patterns.py
@@ -1,6 +1,4 @@
-from pathlib import Path
-
-from expected_result import ExpectedResult
+from expected_result import ExpectedDwyuFailure, ExpectedFailure
 from test_case import TestCaseBase
 
 from test.support.result import Result
@@ -8,17 +6,17 @@ from test.support.result import Result
 
 class TestCase(TestCaseBase):
     def execute_test_logic(self) -> Result:
-        expected_invalid_includes = [
-            "In file 'ignore_includes/use_not_ignored_header.h' include: \"support/a_substring_match_does_not_work_here.h\""
-            if self._cpp_impl_based
-            else f"File='{Path('ignore_includes/use_not_ignored_header.h')}', include='support/a_substring_match_does_not_work_here.h'"
-        ]
-        expected = ExpectedResult(
-            success=False,
-            invalid_includes=expected_invalid_includes,
+        target = "//ignore_includes:use_not_ignored_header"
+        expected = ExpectedFailure(
+            ExpectedDwyuFailure(
+                target=target,
+                invalid_includes={
+                    "ignore_includes/use_not_ignored_header.h": ["support/a_substring_match_does_not_work_here.h"]
+                },
+            )
         )
         actual = self._run_dwyu(
-            target="//ignore_includes:use_not_ignored_header",
+            target=target,
             aspect=self.choose_aspect("//ignore_includes:aspect.bzl%extra_ignore_include_patterns_aspect"),
         )
 

--- a/test/aspect/ignore_toolchain_headers/test_custom_toolchain_headers_info.py
+++ b/test/aspect/ignore_toolchain_headers/test_custom_toolchain_headers_info.py
@@ -1,4 +1,4 @@
-from expected_result import ExpectedResult
+from expected_result import ExpectedSuccess
 from test_case import Compatibility, Compatible, Incompatible, TestCaseBase
 
 from test.support.result import Result
@@ -14,10 +14,9 @@ class TestCase(TestCaseBase):
         return Incompatible("Not compatible with the C++ based implementation")
 
     def execute_test_logic(self) -> Result:
-        expected = ExpectedResult(success=True)
         actual = self._run_dwyu(
             target="//ignore_toolchain_headers:use_custom_toolchain_header",
             aspect=self.choose_aspect("//ignore_toolchain_headers:aspect.bzl%dwyu_custom_toolchain_headers_info"),
         )
 
-        return self._check_result(actual=actual, expected=expected)
+        return self._check_result(actual=actual, expected=ExpectedSuccess())

--- a/test/aspect/ignore_toolchain_headers/test_infer_toolchain_headers.py
+++ b/test/aspect/ignore_toolchain_headers/test_infer_toolchain_headers.py
@@ -1,4 +1,4 @@
-from expected_result import ExpectedResult
+from expected_result import ExpectedSuccess
 from test_case import Compatibility, Compatible, Incompatible, TestCaseBase
 
 from test.support.result import Result
@@ -20,10 +20,9 @@ class TestCase(TestCaseBase):
         return Incompatible("Not compatible with the C++ based implementation")
 
     def execute_test_logic(self) -> Result:
-        expected = ExpectedResult(success=True)
         actual = self._run_dwyu(
             target="//ignore_toolchain_headers:use_toolchain_header",
             aspect=self.choose_aspect("//ignore_toolchain_headers:aspect.bzl%dwyu_ignore_toolchain_headers"),
         )
 
-        return self._check_result(actual=actual, expected=expected)
+        return self._check_result(actual=actual, expected=ExpectedSuccess())

--- a/test/aspect/implementation_deps/test_proper_deps.py
+++ b/test/aspect/implementation_deps/test_proper_deps.py
@@ -1,4 +1,4 @@
-from expected_result import ExpectedResult
+from expected_result import ExpectedSuccess
 from test_case import TestCaseBase
 
 from test.support.result import Result
@@ -6,7 +6,6 @@ from test.support.result import Result
 
 class TestCase(TestCaseBase):
     def execute_test_logic(self) -> Result:
-        expected = ExpectedResult(success=True)
         actual = self._run_dwyu(
             target=[
                 "//implementation_deps:proper_private_deps",
@@ -19,4 +18,4 @@ class TestCase(TestCaseBase):
             aspect=self.choose_aspect("//implementation_deps:aspect.bzl%optimize_impl_deps"),
         )
 
-        return self._check_result(actual=actual, expected=expected)
+        return self._check_result(actual=actual, expected=ExpectedSuccess())

--- a/test/aspect/implementation_deps/test_superfluous_public_dep.py
+++ b/test/aspect/implementation_deps/test_superfluous_public_dep.py
@@ -1,4 +1,4 @@
-from expected_result import ExpectedResult
+from expected_result import ExpectedDwyuFailure, ExpectedFailure
 from test_case import TestCaseBase
 
 from test.support.result import Result
@@ -6,10 +6,12 @@ from test.support.result import Result
 
 class TestCase(TestCaseBase):
     def execute_test_logic(self) -> Result:
-        expected = ExpectedResult(success=False, deps_which_should_be_private=["//implementation_deps/support:lib_b"])
+        target = "//implementation_deps:superfluous_public_dep"
+        expected = ExpectedFailure(
+            ExpectedDwyuFailure(target=target, deps_which_should_be_private=["//implementation_deps/support:lib_b"])
+        )
         actual = self._run_dwyu(
-            target="//implementation_deps:superfluous_public_dep",
-            aspect=self.choose_aspect("//implementation_deps:aspect.bzl%optimize_impl_deps"),
+            target=target, aspect=self.choose_aspect("//implementation_deps:aspect.bzl%optimize_impl_deps")
         )
 
         return self._check_result(actual=actual, expected=expected)

--- a/test/aspect/includes/test_system_includes.py
+++ b/test/aspect/includes/test_system_includes.py
@@ -1,4 +1,4 @@
-from expected_result import ExpectedResult
+from expected_result import ExpectedSuccess
 from test_case import TestCaseBase
 
 from test.support.result import Result
@@ -6,7 +6,6 @@ from test.support.result import Result
 
 class TestCase(TestCaseBase):
     def execute_test_logic(self) -> Result:
-        expected = ExpectedResult(success=True)
         actual = self._run_dwyu(target="//includes:all", aspect=self.default_aspect)
 
-        return self._check_result(actual=actual, expected=expected)
+        return self._check_result(actual=actual, expected=ExpectedSuccess())

--- a/test/aspect/multiple_deps_for_one_header/test_multiple_deps_for_one_header.py
+++ b/test/aspect/multiple_deps_for_one_header/test_multiple_deps_for_one_header.py
@@ -1,4 +1,4 @@
-from expected_result import ExpectedResult
+from expected_result import ExpectedSuccess
 from test_case import TestCaseBase
 
 from test.support.result import Result
@@ -10,7 +10,6 @@ class TestCase(TestCaseBase):
         Multiple dependencies providing the same header can be considered an antipattern. Still, with respect to the
         DWYU principles it is not wrong. Such cases should not cause a DWYU error.
         """
-        expected = ExpectedResult(success=True)
         actual = self._run_dwyu(target="//multiple_deps_for_one_header:foo", aspect=self.default_aspect)
 
-        return self._check_result(actual=actual, expected=expected)
+        return self._check_result(actual=actual, expected=ExpectedSuccess())

--- a/test/aspect/no_preprocessor/test_no_preprocessor.py
+++ b/test/aspect/no_preprocessor/test_no_preprocessor.py
@@ -1,4 +1,4 @@
-from expected_result import ExpectedResult
+from expected_result import ExpectedSuccess
 from test_case import TestCaseBase
 
 from test.support.result import Result
@@ -6,10 +6,9 @@ from test.support.result import Result
 
 class TestCase(TestCaseBase):
     def execute_test_logic(self) -> Result:
-        expected = ExpectedResult(success=True)
         actual = self._run_dwyu(
             target="//no_preprocessor:use_libs",
             aspect=self.choose_aspect("//no_preprocessor:aspect.bzl%dwyu_no_preprocessor"),
         )
 
-        return self._check_result(actual=actual, expected=expected)
+        return self._check_result(actual=actual, expected=ExpectedSuccess())

--- a/test/aspect/platforms/test_ignore_incompatible_platforms.py
+++ b/test/aspect/platforms/test_ignore_incompatible_platforms.py
@@ -1,4 +1,4 @@
-from expected_result import ExpectedResult
+from expected_result import ExpectedSuccess
 from test_case import TestCaseBase
 
 from test.support.result import Result
@@ -6,7 +6,6 @@ from test.support.result import Result
 
 class TestCase(TestCaseBase):
     def execute_test_logic(self) -> Result:
-        expected = ExpectedResult(success=True)
         actual = self._run_dwyu(target="//platforms:all", aspect=self.default_aspect)
 
-        return self._check_result(actual=actual, expected=expected)
+        return self._check_result(actual=actual, expected=ExpectedSuccess())

--- a/test/aspect/preprocessing/test_preprocessing.py
+++ b/test/aspect/preprocessing/test_preprocessing.py
@@ -1,4 +1,4 @@
-from expected_result import ExpectedResult
+from expected_result import ExpectedSuccess
 from test_case import Compatibility, Compatible, Incompatible, TestCaseBase
 
 from test.support.result import Result
@@ -12,7 +12,6 @@ class TestCase(TestCaseBase):
         return Incompatible("Not compatible with the Python based implementation")
 
     def execute_test_logic(self) -> Result:
-        expected = ExpectedResult(success=True)
         actual = self._run_dwyu(target="//preprocessing:all", aspect=self.default_aspect)
 
-        return self._check_result(actual=actual, expected=expected)
+        return self._check_result(actual=actual, expected=ExpectedSuccess())

--- a/test/aspect/preprocessing/test_preprocessing_with_cli_cxxopt.py
+++ b/test/aspect/preprocessing/test_preprocessing_with_cli_cxxopt.py
@@ -1,4 +1,4 @@
-from expected_result import ExpectedResult
+from expected_result import ExpectedSuccess
 from test_case import Compatibility, Compatible, Incompatible, TestCaseBase
 
 from test.support.result import Result
@@ -12,7 +12,6 @@ class TestCase(TestCaseBase):
         return Incompatible("Not compatible with the Python based implementation")
 
     def execute_test_logic(self) -> Result:
-        expected = ExpectedResult(success=True)
         actual = self._run_dwyu(
             target="//preprocessing:select_includes_via_external_macros_with_cli_cxxopt",
             extra_args=[
@@ -23,4 +22,4 @@ class TestCase(TestCaseBase):
             aspect=self.default_aspect,
         )
 
-        return self._check_result(actual=actual, expected=expected)
+        return self._check_result(actual=actual, expected=ExpectedSuccess())

--- a/test/aspect/recursion/test_find_transitive_problem_via_deps.py
+++ b/test/aspect/recursion/test_find_transitive_problem_via_deps.py
@@ -1,4 +1,4 @@
-from expected_result import ExpectedResult
+from expected_result import ExpectedDwyuFailure, ExpectedFailure
 from test_case import TestCaseBase
 
 from test.support.result import Result
@@ -6,7 +6,7 @@ from test.support.result import Result
 
 class TestCase(TestCaseBase):
     def execute_test_logic(self) -> Result:
-        expected = ExpectedResult(success=False, unused_public_deps=["//recursion:e"])
+        expected = ExpectedFailure(ExpectedDwyuFailure(target="//recursion:c", unused_public_deps=["//recursion:e"]))
         actual = self._run_dwyu(
             target="//recursion:main", aspect=self.choose_aspect("//recursion:aspect.bzl%dwyu_recursive")
         )

--- a/test/aspect/recursion/test_find_transitive_problem_via_iml_deps.py
+++ b/test/aspect/recursion/test_find_transitive_problem_via_iml_deps.py
@@ -1,4 +1,4 @@
-from expected_result import ExpectedResult
+from expected_result import ExpectedDwyuFailure, ExpectedFailure
 from test_case import TestCaseBase
 
 from test.support.result import Result
@@ -6,7 +6,7 @@ from test.support.result import Result
 
 class TestCase(TestCaseBase):
     def execute_test_logic(self) -> Result:
-        expected = ExpectedResult(success=False, unused_public_deps=["//recursion:e"])
+        expected = ExpectedFailure(ExpectedDwyuFailure(target="//recursion:c", unused_public_deps=["//recursion:e"]))
         actual = self._run_dwyu(
             target="//recursion:use_impl_deps", aspect=self.choose_aspect("//recursion:aspect.bzl%dwyu_recursive")
         )

--- a/test/aspect/relative_includes/test_relative_includes.py
+++ b/test/aspect/relative_includes/test_relative_includes.py
@@ -1,4 +1,4 @@
-from expected_result import ExpectedResult
+from expected_result import ExpectedSuccess
 from test_case import TestCaseBase
 
 from test.support.result import Result
@@ -6,7 +6,6 @@ from test.support.result import Result
 
 class TestCase(TestCaseBase):
     def execute_test_logic(self) -> Result:
-        expected = ExpectedResult(success=True)
         actual = self._run_dwyu(target="//relative_includes:all", aspect=self.default_aspect)
 
-        return self._check_result(actual=actual, expected=expected)
+        return self._check_result(actual=actual, expected=ExpectedSuccess())

--- a/test/aspect/rule_using_aspect/test_dwyu_rule.py
+++ b/test/aspect/rule_using_aspect/test_dwyu_rule.py
@@ -1,4 +1,4 @@
-from expected_result import ExpectedResult
+from expected_result import ExpectedSuccess
 from test_case import TestCaseBase
 
 from test.support.result import Result
@@ -6,7 +6,6 @@ from test.support.result import Result
 
 class TestCase(TestCaseBase):
     def execute_test_logic(self) -> Result:
-        expected = ExpectedResult(success=True)
         actual = self._run_bazel_build(target=self.choose_target("//rule_using_aspect:dwyu_direct_main"))
 
-        return self._check_result(actual=actual, expected=expected)
+        return self._check_result(actual=actual, expected=ExpectedSuccess())

--- a/test/aspect/rule_using_aspect/test_recursive_dwyu_rule.py
+++ b/test/aspect/rule_using_aspect/test_recursive_dwyu_rule.py
@@ -1,4 +1,4 @@
-from expected_result import ExpectedResult
+from expected_result import ExpectedDwyuFailure, ExpectedFailure
 from test_case import TestCaseBase
 
 from test.support.result import Result
@@ -6,7 +6,9 @@ from test.support.result import Result
 
 class TestCase(TestCaseBase):
     def execute_test_logic(self) -> Result:
-        expected = ExpectedResult(success=False, unused_public_deps=["//rule_using_aspect:c"])
+        expected = ExpectedFailure(
+            ExpectedDwyuFailure(target="//rule_using_aspect:b", unused_public_deps=["//rule_using_aspect:c"])
+        )
         actual = self._run_bazel_build(target=self.choose_target("//rule_using_aspect:dwyu_recursive_main"))
 
         return self._check_result(actual=actual, expected=expected)

--- a/test/aspect/set_cpp_standard/test_set_cplusplus.py
+++ b/test/aspect/set_cpp_standard/test_set_cplusplus.py
@@ -1,4 +1,4 @@
-from expected_result import ExpectedResult
+from expected_result import ExpectedSuccess
 from test_case import TestCaseBase
 
 from test.support.result import Result
@@ -6,9 +6,8 @@ from test.support.result import Result
 
 class TestCase(TestCaseBase):
     def execute_test_logic(self) -> Result:
-        expected = ExpectedResult(success=True)
         actual = self._run_dwyu(
             target="//set_cpp_standard:all", aspect=self.choose_aspect("//set_cpp_standard:aspect.bzl%set_cplusplus")
         )
 
-        return self._check_result(actual=actual, expected=expected)
+        return self._check_result(actual=actual, expected=ExpectedSuccess())

--- a/test/aspect/shared_library/test_shared_library_without_srcs.py
+++ b/test/aspect/shared_library/test_shared_library_without_srcs.py
@@ -1,4 +1,4 @@
-from expected_result import ExpectedResult
+from expected_result import ExpectedSuccess
 from test_case import TestCaseBase
 
 from test.support.result import Result
@@ -6,7 +6,6 @@ from test.support.result import Result
 
 class TestCase(TestCaseBase):
     def execute_test_logic(self) -> Result:
-        expected = ExpectedResult(success=True)
         actual = self._run_dwyu(target="//shared_library:libfoo.so", aspect=self.default_aspect)
 
-        return self._check_result(actual=actual, expected=expected)
+        return self._check_result(actual=actual, expected=ExpectedSuccess())

--- a/test/aspect/skip_external_targets/test_skip_broken_target.py
+++ b/test/aspect/skip_external_targets/test_skip_broken_target.py
@@ -1,4 +1,4 @@
-from expected_result import ExpectedResult
+from expected_result import ExpectedSuccess
 from test_case import TestCaseBase
 
 from test.support.result import Result
@@ -7,10 +7,9 @@ from test.support.result import Result
 class TestCase(TestCaseBase):
     def execute_test_logic(self) -> Result:
         # If we would not skip all external targets the analysis would find an issue with the broken dependency
-        expected = ExpectedResult(success=True)
         actual = self._run_dwyu(
             target="@skip_external_deps_test_repo//:broken_dep",
             aspect=self.choose_aspect("//skip_external_targets:aspect.bzl%dwyu_skip_external"),
         )
 
-        return self._check_result(actual=actual, expected=expected)
+        return self._check_result(actual=actual, expected=ExpectedSuccess())

--- a/test/aspect/skip_tags/test_skip_custom_tag.py
+++ b/test/aspect/skip_tags/test_skip_custom_tag.py
@@ -1,4 +1,4 @@
-from expected_result import ExpectedResult
+from expected_result import ExpectedSuccess
 from test_case import TestCaseBase
 
 from test.support.result import Result
@@ -6,10 +6,9 @@ from test.support.result import Result
 
 class TestCase(TestCaseBase):
     def execute_test_logic(self) -> Result:
-        expected = ExpectedResult(success=True)
         actual = self._run_dwyu(
             target="//skip_tags:ignored_by_custom_tag",
             aspect=self.choose_aspect("//skip_tags:aspect.bzl%dwyu_custom_tags"),
         )
 
-        return self._check_result(actual=actual, expected=expected)
+        return self._check_result(actual=actual, expected=ExpectedSuccess())

--- a/test/aspect/skip_tags/test_skip_no_dwyu_tag.py
+++ b/test/aspect/skip_tags/test_skip_no_dwyu_tag.py
@@ -1,4 +1,4 @@
-from expected_result import ExpectedResult
+from expected_result import ExpectedSuccess
 from test_case import TestCaseBase
 
 from test.support.result import Result
@@ -6,7 +6,6 @@ from test.support.result import Result
 
 class TestCase(TestCaseBase):
     def execute_test_logic(self) -> Result:
-        expected = ExpectedResult(success=True)
         actual = self._run_dwyu(target="//skip_tags:ignored_by_default_behavior", aspect=self.default_aspect)
 
-        return self._check_result(actual=actual, expected=expected)
+        return self._check_result(actual=actual, expected=ExpectedSuccess())

--- a/test/aspect/target_mapping/test_use_b_via_impl_deps_with_specific_mapping.py
+++ b/test/aspect/target_mapping/test_use_b_via_impl_deps_with_specific_mapping.py
@@ -1,4 +1,4 @@
-from expected_result import ExpectedResult
+from expected_result import ExpectedSuccess
 from test_case import TestCaseBase
 
 from test.support.result import Result
@@ -6,10 +6,9 @@ from test.support.result import Result
 
 class TestCase(TestCaseBase):
     def execute_test_logic(self) -> Result:
-        expected = ExpectedResult(success=True)
         actual = self._run_dwyu(
             target="//target_mapping:use_lib_b_privately",
             aspect=self.choose_aspect("//target_mapping:aspect.bzl%map_specific_deps"),
         )
 
-        return self._check_result(actual=actual, expected=expected)
+        return self._check_result(actual=actual, expected=ExpectedSuccess())

--- a/test/aspect/target_mapping/test_use_b_with_direct_deps_mapping.py
+++ b/test/aspect/target_mapping/test_use_b_with_direct_deps_mapping.py
@@ -1,4 +1,4 @@
-from expected_result import ExpectedResult
+from expected_result import ExpectedSuccess
 from test_case import TestCaseBase
 
 from test.support.result import Result
@@ -6,10 +6,9 @@ from test.support.result import Result
 
 class TestCase(TestCaseBase):
     def execute_test_logic(self) -> Result:
-        expected = ExpectedResult(success=True)
         actual = self._run_dwyu(
             target="//target_mapping:use_lib_b",
             aspect=self.choose_aspect("//target_mapping:aspect.bzl%map_direct_deps"),
         )
 
-        return self._check_result(actual=actual, expected=expected)
+        return self._check_result(actual=actual, expected=ExpectedSuccess())

--- a/test/aspect/target_mapping/test_use_b_with_specific_mapping.py
+++ b/test/aspect/target_mapping/test_use_b_with_specific_mapping.py
@@ -1,4 +1,4 @@
-from expected_result import ExpectedResult
+from expected_result import ExpectedSuccess
 from test_case import TestCaseBase
 
 from test.support.result import Result
@@ -6,10 +6,9 @@ from test.support.result import Result
 
 class TestCase(TestCaseBase):
     def execute_test_logic(self) -> Result:
-        expected = ExpectedResult(success=True)
         actual = self._run_dwyu(
             target="//target_mapping:use_lib_b",
             aspect=self.choose_aspect("//target_mapping:aspect.bzl%map_specific_deps"),
         )
 
-        return self._check_result(actual=actual, expected=expected)
+        return self._check_result(actual=actual, expected=ExpectedSuccess())

--- a/test/aspect/target_mapping/test_use_b_with_transitive_deps_mapping.py
+++ b/test/aspect/target_mapping/test_use_b_with_transitive_deps_mapping.py
@@ -1,4 +1,4 @@
-from expected_result import ExpectedResult
+from expected_result import ExpectedSuccess
 from test_case import TestCaseBase
 
 from test.support.result import Result
@@ -6,10 +6,9 @@ from test.support.result import Result
 
 class TestCase(TestCaseBase):
     def execute_test_logic(self) -> Result:
-        expected = ExpectedResult(success=True)
         actual = self._run_dwyu(
             target="//target_mapping:use_lib_b",
             aspect=self.choose_aspect("//target_mapping:aspect.bzl%map_transitive_deps"),
         )
 
-        return self._check_result(actual=actual, expected=expected)
+        return self._check_result(actual=actual, expected=ExpectedSuccess())

--- a/test/aspect/target_mapping/test_use_c_with_direct_deps_mapping.py
+++ b/test/aspect/target_mapping/test_use_c_with_direct_deps_mapping.py
@@ -1,6 +1,4 @@
-from pathlib import Path
-
-from expected_result import ExpectedResult
+from expected_result import ExpectedDwyuFailure, ExpectedFailure
 from test_case import TestCaseBase
 
 from test.support.result import Result
@@ -8,19 +6,14 @@ from test.support.result import Result
 
 class TestCase(TestCaseBase):
     def execute_test_logic(self) -> Result:
-        expected_invalid_includes = [
-            "In file 'target_mapping/use_lib_c.cpp' include: \"target_mapping/libs/c.h\""
-            if self._cpp_impl_based
-            else f"File='{Path('target_mapping/use_lib_c.cpp')}', include='target_mapping/libs/c.h'"
-        ]
-        expected = ExpectedResult(
-            success=False,
-            invalid_includes=expected_invalid_includes,
-            unused_public_deps=["//target_mapping/libs:a"],
+        target = "//target_mapping:use_lib_c"
+        expected = ExpectedFailure(
+            ExpectedDwyuFailure(
+                target=target,
+                invalid_includes={"target_mapping/use_lib_c.cpp": ["target_mapping/libs/c.h"]},
+                unused_public_deps=["//target_mapping/libs:a"],
+            )
         )
-        actual = self._run_dwyu(
-            target="//target_mapping:use_lib_c",
-            aspect=self.choose_aspect("//target_mapping:aspect.bzl%map_direct_deps"),
-        )
+        actual = self._run_dwyu(target=target, aspect=self.choose_aspect("//target_mapping:aspect.bzl%map_direct_deps"))
 
         return self._check_result(actual=actual, expected=expected)

--- a/test/aspect/target_mapping/test_use_c_with_specific_mapping.py
+++ b/test/aspect/target_mapping/test_use_c_with_specific_mapping.py
@@ -1,6 +1,4 @@
-from pathlib import Path
-
-from expected_result import ExpectedResult
+from expected_result import ExpectedDwyuFailure, ExpectedFailure
 from test_case import TestCaseBase
 
 from test.support.result import Result
@@ -8,19 +6,16 @@ from test.support.result import Result
 
 class TestCase(TestCaseBase):
     def execute_test_logic(self) -> Result:
-        expected_invalid_includes = [
-            "In file 'target_mapping/use_lib_c.cpp' include: \"target_mapping/libs/c.h\""
-            if self._cpp_impl_based
-            else f"File='{Path('target_mapping/use_lib_c.cpp')}', include='target_mapping/libs/c.h'"
-        ]
-        expected = ExpectedResult(
-            success=False,
-            invalid_includes=expected_invalid_includes,
-            unused_public_deps=["//target_mapping/libs:a"],
+        target = "//target_mapping:use_lib_c"
+        expected = ExpectedFailure(
+            ExpectedDwyuFailure(
+                target=target,
+                invalid_includes={"target_mapping/use_lib_c.cpp": ["target_mapping/libs/c.h"]},
+                unused_public_deps=["//target_mapping/libs:a"],
+            )
         )
         actual = self._run_dwyu(
-            target="//target_mapping:use_lib_c",
-            aspect=self.choose_aspect("//target_mapping:aspect.bzl%map_specific_deps"),
+            target=target, aspect=self.choose_aspect("//target_mapping:aspect.bzl%map_specific_deps")
         )
 
         return self._check_result(actual=actual, expected=expected)

--- a/test/aspect/target_mapping/test_use_c_with_transitive_deps_mapping.py
+++ b/test/aspect/target_mapping/test_use_c_with_transitive_deps_mapping.py
@@ -1,4 +1,4 @@
-from expected_result import ExpectedResult
+from expected_result import ExpectedSuccess
 from test_case import TestCaseBase
 
 from test.support.result import Result
@@ -6,10 +6,9 @@ from test.support.result import Result
 
 class TestCase(TestCaseBase):
     def execute_test_logic(self) -> Result:
-        expected = ExpectedResult(success=True)
         actual = self._run_dwyu(
             target="//target_mapping:use_lib_c",
             aspect=self.choose_aspect("//target_mapping:aspect.bzl%map_transitive_deps"),
         )
 
-        return self._check_result(actual=actual, expected=expected)
+        return self._check_result(actual=actual, expected=ExpectedSuccess())

--- a/test/aspect/test_case_test.py
+++ b/test/aspect/test_case_test.py
@@ -52,10 +52,11 @@ class TestCaseTests(unittest.TestCase):
     @patch("subprocess.run")
     def test_get_success(self, _: MagicMock) -> None:
         result = self.unit.execute_test(
-            version=TestedVersions(bazel="6.4.2", python="13.37"),
+            version=TestedVersions(bazel="13.3.7", python="13.37"),
             bazel_bin=self.unit.bazel_binary,
             output_base=Path("/some/path"),
             extra_args=[],
+            reports_root=Path("reports"),
         )
         self.assertTrue(result.is_success())
 
@@ -63,10 +64,11 @@ class TestCaseTests(unittest.TestCase):
     def test_get_error(self, _: MagicMock) -> None:
         self.unit.result = Error("some failure")
         result = self.unit.execute_test(
-            version=TestedVersions(bazel="6.4.2", python="13.37"),
+            version=TestedVersions(bazel="13.3.7", python="13.37"),
             bazel_bin=self.unit.bazel_binary,
             output_base=Path("/some/path"),
             extra_args=[],
+            reports_root=Path("reports"),
         )
         self.assertFalse(result.is_success())
         self.assertEqual(result.error, "some failure")
@@ -74,10 +76,11 @@ class TestCaseTests(unittest.TestCase):
     @patch("subprocess.run")
     def test_dwyu_command_without_any_extra_args(self, run_mock: MagicMock) -> None:
         self.unit.execute_test(
-            version=TestedVersions(bazel="6.4.2", python="13.37"),
+            version=TestedVersions(bazel="13.3.7", python="13.37"),
             bazel_bin=self.unit.bazel_binary,
             output_base=Path("/some/path"),
             extra_args=[],
+            reports_root=Path("reports"),
         )
 
         run_mock.assert_called_once()
@@ -98,16 +101,17 @@ class TestCaseTests(unittest.TestCase):
                 "//foo:bar",
             ],
         )
-        self.assertEqual(self.get_env(run_mock)["USE_BAZEL_VERSION"], "6.4.2")
+        self.assertEqual(self.get_env(run_mock)["USE_BAZEL_VERSION"], "13.3.7")
 
     @patch("subprocess.run")
     def test_dwyu_command_with_global_and_dwyu_extra_args(self, run_mock: MagicMock) -> None:
         self.unit.dwyu_extra_args = ["--some_arg=42", "--another_arg"]
         self.unit.execute_test(
-            version=TestedVersions(bazel="6.4.2", python="13.37"),
+            version=TestedVersions(bazel="13.3.7", python="13.37"),
             bazel_bin=self.unit.bazel_binary,
             output_base=Path("/some/path"),
             extra_args=["--global_arg=23", "--another_global_arg"],
+            reports_root=Path("reports"),
         )
 
         run_mock.assert_called_once()
@@ -132,16 +136,17 @@ class TestCaseTests(unittest.TestCase):
                 "//foo:bar",
             ],
         )
-        self.assertEqual(self.get_env(run_mock)["USE_BAZEL_VERSION"], "6.4.2")
+        self.assertEqual(self.get_env(run_mock)["USE_BAZEL_VERSION"], "13.3.7")
 
     @patch("subprocess.run")
     def test_dwyu_command_with_multiple_targets(self, run_mock: MagicMock) -> None:
         self.unit.target = ["//foo:bar", "//tick:tock"]
         self.unit.execute_test(
-            version=TestedVersions(bazel="6.4.2", python="13.37"),
+            version=TestedVersions(bazel="13.3.7", python="13.37"),
             bazel_bin=self.unit.bazel_binary,
             output_base=Path("/some/path"),
             extra_args=[],
+            reports_root=Path("reports"),
         )
 
         run_mock.assert_called_once()
@@ -163,7 +168,7 @@ class TestCaseTests(unittest.TestCase):
                 "//tick:tock",
             ],
         )
-        self.assertEqual(self.get_env(run_mock)["USE_BAZEL_VERSION"], "6.4.2")
+        self.assertEqual(self.get_env(run_mock)["USE_BAZEL_VERSION"], "13.3.7")
 
 
 if __name__ == "__main__":

--- a/test/aspect/tree_artifact/test_invalid_tree_artifact.py
+++ b/test/aspect/tree_artifact/test_invalid_tree_artifact.py
@@ -1,6 +1,4 @@
-from pathlib import Path
-
-from expected_result import ExpectedResult
+from expected_result import ExpectedDwyuFailure, ExpectedFailure
 from test_case import TestCaseBase
 
 from test.support.result import Result
@@ -8,20 +6,15 @@ from test.support.result import Result
 
 class TestCase(TestCaseBase):
     def execute_test_logic(self) -> Result:
-        # We omit "In file '..." to allow testing in various environments, since this is generated code in the
-        #  bazel-out/.../bin/ dir, whose exact path is platform dependent
-        expected_invalid_includes = [
-            'tree_artifact/sources.cc/tree_lib.cc\' include: "tree_artifact/some_lib.h"'
-            if self._cpp_impl_based
-            else f"{Path('tree_artifact/sources.cc/tree_lib.cc')}', include='tree_artifact/some_lib.h'"
-        ]
-        expected = ExpectedResult(
-            success=False,
-            invalid_includes=expected_invalid_includes,
+        # The exact path of a generated file depends on the target platform. Thus, we have to compute it here.
+        bazel_bin = self._run_bazel_info("bazel-bin").stdout.strip()
+        generated_sources_prefix = "bazel-out/" + bazel_bin.split("/bazel-out/")[1]
+        generated_file = generated_sources_prefix + "/" + "tree_artifact/sources.cc/tree_lib.cc"
+
+        target = "//tree_artifact:tree_artifact_library"
+        expected = ExpectedFailure(
+            [ExpectedDwyuFailure(target=target, invalid_includes={generated_file: ["tree_artifact/some_lib.h"]})]
         )
-        actual = self._run_dwyu(
-            target="//tree_artifact:tree_artifact_library",
-            aspect=self.default_aspect,
-        )
+        actual = self._run_dwyu(target=target, aspect=self.default_aspect)
 
         return self._check_result(actual=actual, expected=expected)

--- a/test/aspect/tree_artifact/test_use_tree_artifact_correctly.py
+++ b/test/aspect/tree_artifact/test_use_tree_artifact_correctly.py
@@ -1,4 +1,4 @@
-from expected_result import ExpectedResult
+from expected_result import ExpectedSuccess
 from test_case import TestCaseBase
 
 from test.support.result import Result
@@ -6,7 +6,6 @@ from test.support.result import Result
 
 class TestCase(TestCaseBase):
     def execute_test_logic(self) -> Result:
-        expected = ExpectedResult(success=True)
         actual = self._run_dwyu(target="//tree_artifact:use_tree_artifact", aspect=self.default_aspect)
 
-        return self._check_result(actual=actual, expected=expected)
+        return self._check_result(actual=actual, expected=ExpectedSuccess())

--- a/test/aspect/unused_dep/test_detect_unused_dep.py
+++ b/test/aspect/unused_dep/test_detect_unused_dep.py
@@ -1,4 +1,4 @@
-from expected_result import ExpectedResult
+from expected_result import ExpectedDwyuFailure, ExpectedFailure
 from test_case import TestCaseBase
 
 from test.support.result import Result
@@ -6,7 +6,8 @@ from test.support.result import Result
 
 class TestCase(TestCaseBase):
     def execute_test_logic(self) -> Result:
-        expected = ExpectedResult(success=False, unused_public_deps=["//unused_dep:foo"])
-        actual = self._run_dwyu(target="//unused_dep:main", aspect=self.default_aspect)
+        target = "//unused_dep:main"
+        expected = ExpectedFailure(ExpectedDwyuFailure(target=target, unused_public_deps=["//unused_dep:foo"]))
+        actual = self._run_dwyu(target=target, aspect=self.default_aspect)
 
         return self._check_result(actual=actual, expected=expected)

--- a/test/aspect/unused_dep/test_detect_unused_impl_dep.py
+++ b/test/aspect/unused_dep/test_detect_unused_impl_dep.py
@@ -1,4 +1,4 @@
-from expected_result import ExpectedResult
+from expected_result import ExpectedDwyuFailure, ExpectedFailure
 from test_case import TestCaseBase
 
 from test.support.result import Result
@@ -6,7 +6,8 @@ from test.support.result import Result
 
 class TestCase(TestCaseBase):
     def execute_test_logic(self) -> Result:
-        expected = ExpectedResult(success=False, unused_private_deps=["//unused_dep:foo"])
-        actual = self._run_dwyu(target="//unused_dep:implementation_deps_lib", aspect=self.default_aspect)
+        target = "//unused_dep:implementation_deps_lib"
+        expected = ExpectedFailure(ExpectedDwyuFailure(target=target, unused_private_deps=["//unused_dep:foo"]))
+        actual = self._run_dwyu(target=target, aspect=self.default_aspect)
 
         return self._check_result(actual=actual, expected=expected)

--- a/test/aspect/using_transitive_dep/test_detect_using_transitive_dep.py
+++ b/test/aspect/using_transitive_dep/test_detect_using_transitive_dep.py
@@ -1,6 +1,4 @@
-from pathlib import Path
-
-from expected_result import ExpectedResult
+from expected_result import ExpectedDwyuFailure, ExpectedFailure
 from test_case import TestCaseBase
 
 from test.support.result import Result
@@ -8,21 +6,18 @@ from test.support.result import Result
 
 class TestCase(TestCaseBase):
     def execute_test_logic(self) -> Result:
-        expected_invalid_includes = (
-            [
-                "In file 'using_transitive_dep/main.cpp' include: \"using_transitive_dep/transitive_dep_hdr.h\"",
-                "In file 'using_transitive_dep/main.cpp' include: \"using_transitive_dep/transitive_dep_src.h\"",
-            ]
-            if self._cpp_impl_based
-            else [
-                f"File='{Path('using_transitive_dep/main.cpp')}', include='using_transitive_dep/transitive_dep_hdr.h'",
-                f"File='{Path('using_transitive_dep/main.cpp')}', include='using_transitive_dep/transitive_dep_hdr.h'",
-            ]
+        target = "//using_transitive_dep:main"
+        expected = ExpectedFailure(
+            ExpectedDwyuFailure(
+                target=target,
+                invalid_includes={
+                    "using_transitive_dep/main.cpp": [
+                        "using_transitive_dep/transitive_dep_hdr.h",
+                        "using_transitive_dep/transitive_dep_src.h",
+                    ]
+                },
+            )
         )
-        expected = ExpectedResult(
-            success=False,
-            invalid_includes=expected_invalid_includes,
-        )
-        actual = self._run_dwyu(target="//using_transitive_dep:main", aspect=self.default_aspect)
+        actual = self._run_dwyu(target=target, aspect=self.default_aspect)
 
         return self._check_result(actual=actual, expected=expected)

--- a/test/aspect/using_transitive_dep/test_detect_using_transitive_impl_dep.py
+++ b/test/aspect/using_transitive_dep/test_detect_using_transitive_impl_dep.py
@@ -1,6 +1,4 @@
-from pathlib import Path
-
-from expected_result import ExpectedResult
+from expected_result import ExpectedDwyuFailure, ExpectedFailure
 from test_case import TestCaseBase
 
 from test.support.result import Result
@@ -8,23 +6,18 @@ from test.support.result import Result
 
 class TestCase(TestCaseBase):
     def execute_test_logic(self) -> Result:
-        expected_invalid_includes = (
-            [
-                "In file 'using_transitive_dep/transitive_usage_through_impl_deps.h' include: \"using_transitive_dep/transitive_dep_hdr.h\"",
-                "In file 'using_transitive_dep/transitive_usage_through_impl_deps.h' include: \"using_transitive_dep/transitive_dep_src.h\"",
-            ]
-            if self._cpp_impl_based
-            else [
-                f"File='{Path('using_transitive_dep/transitive_usage_through_impl_deps.h')}', include='using_transitive_dep/transitive_dep_hdr.h'",
-                f"File='{Path('using_transitive_dep/transitive_usage_through_impl_deps.h')}', include='using_transitive_dep/transitive_dep_hdr.h'",
-            ]
+        target = "//using_transitive_dep:transitive_usage_through_impl_deps"
+        expected = ExpectedFailure(
+            ExpectedDwyuFailure(
+                target=target,
+                invalid_includes={
+                    "using_transitive_dep/transitive_usage_through_impl_deps.h": [
+                        "using_transitive_dep/transitive_dep_hdr.h",
+                        "using_transitive_dep/transitive_dep_src.h",
+                    ]
+                },
+            )
         )
-        expected = ExpectedResult(
-            success=False,
-            invalid_includes=expected_invalid_includes,
-        )
-        actual = self._run_dwyu(
-            target="//using_transitive_dep:transitive_usage_through_impl_deps", aspect=self.default_aspect
-        )
+        actual = self._run_dwyu(target=target, aspect=self.default_aspect)
 
         return self._check_result(actual=actual, expected=expected)

--- a/test/aspect/valid/test_common_valid_case.py
+++ b/test/aspect/valid/test_common_valid_case.py
@@ -1,4 +1,4 @@
-from expected_result import ExpectedResult
+from expected_result import ExpectedSuccess
 from test_case import TestCaseBase
 
 from test.support.result import Result
@@ -6,7 +6,6 @@ from test.support.result import Result
 
 class TestCase(TestCaseBase):
     def execute_test_logic(self) -> Result:
-        expected = ExpectedResult(success=True)
         actual = self._run_dwyu(target="//valid:bar", aspect=self.default_aspect)
 
-        return self._check_result(actual=actual, expected=expected)
+        return self._check_result(actual=actual, expected=ExpectedSuccess())

--- a/test/aspect/virtual_includes/test_correctly_process_virtual_includes.py
+++ b/test/aspect/virtual_includes/test_correctly_process_virtual_includes.py
@@ -1,4 +1,4 @@
-from expected_result import ExpectedResult
+from expected_result import ExpectedSuccess
 from test_case import TestCaseBase
 
 from test.support.result import Result
@@ -6,7 +6,6 @@ from test.support.result import Result
 
 class TestCase(TestCaseBase):
     def execute_test_logic(self) -> Result:
-        expected = ExpectedResult(success=True)
         actual = self._run_dwyu(target="//virtual_includes:all", aspect=self.default_aspect)
 
-        return self._check_result(actual=actual, expected=expected)
+        return self._check_result(actual=actual, expected=ExpectedSuccess())


### PR DESCRIPTION
The report files are well structured and suited for machine reading. In contrast, the terminal output is focused on readability for humans. Furthermore, using the report files gives us the freedom to expect multiple failures in a single test case without having to implement a more complex terminal parsing logic.