### PR TITLE
refactor: Restructure MODULE.bazel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -30,15 +30,16 @@ bazel_dep(name = "zstd", version = "1.5.5.bcr.1")
 ###
 
 bazel_dep(name = "aspect_bazel_lib", version = "2.22.2", dev_dependency = True)
+bazel_dep(name = "googletest", version = "1.17.0.bcr.2", dev_dependency = True)
+bazel_dep(name = "protobuf", version = "33.4", dev_dependency = True)
+bazel_dep(name = "toolchains_llvm", version = "1.6.0", dev_dependency = True)
+
+###
+### Development Toolchains
+###
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python", dev_dependency = True)
 python.toolchain(python_version = "3.8")
-
-bazel_dep(name = "googletest", version = "1.17.0.bcr.2", dev_dependency = True)
-
-# protobuf is a transitive dependencies of our docs generation. We desire a version providing precompiled protoc.
-bazel_dep(name = "protobuf", version = "33.4", dev_dependency = True)
-bazel_dep(name = "toolchains_llvm", version = "1.6.0", dev_dependency = True)
 
 llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm", dev_dependency = True)
 llvm.toolchain(


### PR DESCRIPTION
- For readability distinguish between dev dependencies and dev toolchains
- Drop the outdated comment for protobuf. protobuf is now a dedicated dev dependency, since we use the precompiled protoc. via `--@protobuf//bazel/toolchains:prefer_prebuilt_protoc`