### PR TITLE
chore: Use standard Bazel rules release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,27 +1,26 @@
 name: Release
 
 on:
+  # Automatically trigger a release when a release tag is pushed.
   push:
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"
 
 permissions:
+  attestations: write
   contents: write
+  id-token: write
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Prepare release
-        run: .github/workflows/prepare_release.py --tag ${GITHUB_REF_NAME}
-      - name: Draft release
-        uses: softprops/action-gh-release@v2
-        with:
-          draft: true
-          prerelease: true
-          generate_release_notes: true
-          body_path: release_notes.txt
-          fail_on_unmatched_files: true
-          files: depend_on_what_you_use-*.tar.gz
+  release:
+    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7.4.0
+    with:
+      # We adapt the release notes before we make the release visible and start deployment to the BCR
+      draft: true
+      prerelease: true
+      generate_release_notes: true
+      release_files: depend_on_what_you_use-*.tar.gz
+      tag_name: ${{ inputs.tag_name }}
+      # The code has already been tested before we start the release process
+      bazel_test_command: "/bin/true"
+      mount_bazel_caches: false

--- a/.github/workflows/release_prep.py
+++ b/.github/workflows/release_prep.py
@@ -87,13 +87,13 @@ def make_archive(tag: str) -> Path:
     return archive
 
 
-def make_release_notes(archive: Path, tag: str) -> None:
+def print_release_notes(archive: Path, tag: str) -> None:
     checksum_process = subprocess.run(["sha256sum", archive], check=True, capture_output=True, text=True)
     checksum = checksum_process.stdout.split(" ", 1)[0]
-    Path("release_notes.txt").write_text(RELEASE_NOTES_TEMPLATE.format(SHA=checksum, VERSION=tag).strip())
+    print(RELEASE_NOTES_TEMPLATE.format(SHA=checksum, VERSION=tag).strip())  # noqa: T201
 
 
 if __name__ == "__main__":
     args = cli()
     release_artifact = make_archive(args.tag)
-    make_release_notes(archive=release_artifact, tag=args.tag)
+    print_release_notes(archive=release_artifact, tag=args.tag)

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o pipefail
+
+# We prefer Python over Bash for scripting
+.github/workflows/release_prep.py --tag $1


### PR DESCRIPTION
This allows us to create attested releases. In a separate step we will also rework the deployment to the BCR, which then can incorporate the attestation.

First step towards https://github.com/martis42/depend_on_what_you_use/issues/369