### PR TITLE
ci: Ensure all jobs are green before releasing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,8 @@
 name: CI
 
-on: [ pull_request ]
+on:
+  pull_request:
+  workflow_call:
 
 jobs:
   pre-commit:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,12 @@ permissions:
   id-token: write
 
 jobs:
+  ci:
+    uses: ./.github/workflows/ci.yaml
+
   release:
+    # Ensure we have a 100% green build before releasing something
+    needs: [ ci ]
     uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7.4.0
     with:
       # We adapt the release notes before we make the release visible and start deployment to the BCR


### PR DESCRIPTION
Make sure we do not overlook a red build due to a breaking change in the Bazel rolling releases or we merged something without full CI runs.