### PR TITLE
ci: Stop testing unstable Bazel version for BCR releases

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -3,7 +3,7 @@ bcr_test_module:
   matrix:
     platform: [ "macos", "ubuntu2204", "windows" ]
     # Keep in syn with: MODULE.bazel, README.md, test/aspect/execute_tests.py and test/workspace_integration/test.py
-    bazel: [ "7.6.0", "8.x", "9.*", "rolling" ]
+    bazel: [ "7.6.0", "8.x", "9.x" ]
   tasks:
     verify_examples:
       name: "Verify examples"


### PR DESCRIPTION
We continue testing rolling releases in our own CI. There we can react anytime by disabling tests or adding workarounds. However if we want to release, we do not want to be blocked by the BCR running tests against something which is not even released yet.