### PR TITLE
chore(deps): Update Bazel rule deps

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,7 +5,7 @@ module(
     bazel_compatibility = [">=7.6.0"],
 )
 
-bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "bazel_skylib", version = "1.8.2")
 bazel_dep(name = "buildozer", version = "8.5.1")
 bazel_dep(name = "nlohmann_json", version = "3.12.0.bcr.1")
 bazel_dep(name = "rules_cc", version = "0.0.15")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,7 +8,7 @@ module(
 bazel_dep(name = "bazel_skylib", version = "1.8.2")
 bazel_dep(name = "buildozer", version = "8.5.1")
 bazel_dep(name = "nlohmann_json", version = "3.12.0.bcr.1")
-bazel_dep(name = "rules_cc", version = "0.0.15")
+bazel_dep(name = "rules_cc", version = "0.2.4")
 bazel_dep(name = "rules_python", version = "1.0.0")
 
 boost_version = "1.83.0.bcr.4"

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,7 +9,7 @@ bazel_dep(name = "bazel_skylib", version = "1.8.2")
 bazel_dep(name = "buildozer", version = "8.5.1")
 bazel_dep(name = "nlohmann_json", version = "3.12.0.bcr.1")
 bazel_dep(name = "rules_cc", version = "0.0.15")
-bazel_dep(name = "rules_python", version = "0.37.2")
+bazel_dep(name = "rules_python", version = "1.0.0")
 
 boost_version = "1.83.0.bcr.4"
 

--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -10,7 +10,7 @@ local_path_override(
 ## One can use DWYU without the content below. We simply need some further things so all examples work.
 ##
 
-bazel_dep(name = "rules_cc", version = "0.0.17")
+bazel_dep(name = "rules_cc", version = "0.2.4")
 
 bazel_dep(name = "external_targets", dev_dependency = True)
 local_path_override(

--- a/test/bcr_release/MODULE.bazel
+++ b/test/bcr_release/MODULE.bazel
@@ -4,4 +4,4 @@ module(name = "test_dwyu_release")
 bazel_dep(name = "depend_on_what_you_use", version = "0.0.0")
 
 # Other deps required by the example code
-bazel_dep(name = "rules_cc", version = "0.0.15")
+bazel_dep(name = "rules_cc", version = "0.2.4")


### PR DESCRIPTION
In preparation for version 1.0.0 we use dependencies which:
- themselves already reached 1.0.0 
- Are not too old (also not older than what Bazel 7.6.0 itself requires)