### PR TITLE
chore: Remove non functional test config

### DIFF
--- a/test/workspace_integration/.bazelrc
+++ b/test/workspace_integration/.bazelrc
@@ -3,6 +3,3 @@ build --experimental_convenience_symlinks=clean
 
 build:dwyu --output_groups=dwyu
 build:dwyu --aspects=//:aspect.bzl%dwyu
-
-build:dwyu_cpp --output_groups=dwyu
-build:dwyu_cpp --aspects=//:aspect.bzl%dwyu_cpp


### PR DESCRIPTION
Leftover from when the legacy Python implementation still existed.