### PR TITLE
test(aspect): Remove boost from complex code tests

### DIFF
--- a/test/aspect/MODULE.bazel
+++ b/test/aspect/MODULE.bazel
@@ -29,7 +29,6 @@ bazel_dep(name = "rules_cc", version = "0.0.1")
 bazel_dep(name = "platforms", version = "0.0.11")
 bazel_dep(name = "rules_shell", version = "0.4.1")
 bazel_dep(name = "googletest", version = "1.17.0.bcr.2")
-bazel_dep(name = "boost.chrono", version = "1.83.0.bcr.4")
 
 ##
 ## Workspaces for test purposes

--- a/test/aspect/preprocessing/BUILD
+++ b/test/aspect/preprocessing/BUILD
@@ -69,7 +69,6 @@ cc_binary(
     name = "use_complex_libraries",
     srcs = ["use_complex_libraries.cpp"],
     deps = [
-        "@boost.chrono",
         "@googletest//:gtest",
     ],
 )

--- a/test/aspect/preprocessing/use_complex_libraries.cpp
+++ b/test/aspect/preprocessing/use_complex_libraries.cpp
@@ -1,5 +1,4 @@
 // Include headers from real projects which are known not to be trivial to preprocess
-#include <boost/chrono.hpp>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
Since DWYU itself now depends on boost, this can cause version mismatches. Instead of having yet another place where we have to keep versions in sync, we drop using boost for the "parse complex code" tests. gtest should be enough for testing this.