### PR TITLE
chore: Use consistent Bazel version style for testing

### DIFF
--- a/test/aspect/execute_tests.py
+++ b/test/aspect/execute_tests.py
@@ -26,7 +26,7 @@ TESTED_VERSIONS = [
     TestedVersions(bazel="7.6.0"),
     TestedVersions(bazel="7.x"),
     TestedVersions(bazel="8.x"),
-    TestedVersions(bazel="9.*", is_default=True),
+    TestedVersions(bazel="9.x", is_default=True),
     TestedVersions(bazel="rolling"),
 ]
 

--- a/test/workspace_integration/test.py
+++ b/test/workspace_integration/test.py
@@ -19,12 +19,12 @@ from test.support.bazel import get_bazel_binary, get_explicit_bazel_version, mak
 logging.basicConfig(format="%(message)s", level=logging.INFO)
 log = logging.getLogger()
 
-# Kep in sync with: MODULE.bazel, README.md, .bcr/presubmit.yml and test/aspect/execute_tests.py
+# Keep in sync with: MODULE.bazel, README.md, .bcr/presubmit.yml and test/aspect/execute_tests.py
 BAZEL_VERSIONS_UNDER_TEST = [
     "7.6.0",
     "7.x",
     "8.x",
-    "9.*",
+    "9.x",
     "rolling",
 ]
 


### PR DESCRIPTION
We used `9.*` during the Bazel 9 release phase. But in general, we only test against released Bazel versions.