### PR TITLE
chore: Hide compiler warnings from boost.wave headers

### DIFF
--- a/third_party/boost/wave/wave.BUILD
+++ b/third_party/boost/wave/wave.BUILD
@@ -4,6 +4,7 @@ cc_library(
     name = "wave",
     srcs = glob(["src/**"]),
     hdrs = glob(["include/**"]),
+    features = ["system_include_paths"],
     includes = ["include"],
     visibility = ["//visibility:public"],
     deps = [


### PR DESCRIPTION
rules_cc 0.2.11 changed how `includes = [..],` works. If one wants to ensure those paths are treated as system includes, then depending on context one has to use the features `external_include_paths` or `system_include_paths`.
For a target whose headers shall always be included as system include without the end user having to take any action (besides using a toolchain understanding the feature), `system_include_paths` is the correct choice.