### PR TITLE
chore: Reduce --noexperimental_python_import_all_repositories support

### DIFF
--- a/dwyu/apply_fixes/BUILD
+++ b/dwyu/apply_fixes/BUILD
@@ -20,7 +20,7 @@ py_binary(
     name = "apply_fixes",
     srcs = ["main.py"],
     data = ["@buildozer_binary//:buildozer.exe"],
-    # Compatibility to --noexperimental_python_import_all_repositories
+    # Compatibility to --experimental_python_import_all_repositories=false
     imports = ["../.."],
     main = "main.py",
     visibility = ["//visibility:public"],

--- a/test/apply_fixes/.bazelrc
+++ b/test/apply_fixes/.bazelrc
@@ -9,6 +9,3 @@ common --check_direct_dependencies=off
 
 # The symlinks are cluttering the file tree without much value
 common --experimental_convenience_symlinks=ignore
-
-# Some users require this setting to mitigate issues due to a large PYTHONPATH created by rules_python
-common --experimental_python_import_all_repositories=false

--- a/test/apply_fixes/test_case.py
+++ b/test/apply_fixes/test_case.py
@@ -90,12 +90,16 @@ class TestCaseBase(ABC):
         self._log_file.write_text(process.stdout)
 
     def _run_automatic_fix(
-        self, extra_args: list[str] | None = None, custom_dwyu_report_discovery: bool = False
+        self,
+        bazel_args: list[str] | None = None,
+        extra_args: list[str] | None = None,
+        custom_dwyu_report_discovery: bool = False,
     ) -> None:
         """
         Execute the applying fixes script for the Bazel target associated with the test case
         """
         verbosity = ["--verbose"] if log.isEnabledFor(logging.DEBUG) else []
+        cmd_bazel_args = bazel_args or []
         cmd_extra_args = extra_args or []
         dwyu_report = [] if custom_dwyu_report_discovery else [f"--dwyu-log-file={self._log_file}"]
 
@@ -104,6 +108,7 @@ class TestCaseBase(ABC):
                 self._bazel_bin,
                 "run",
                 "@depend_on_what_you_use//dwyu/apply_fixes:apply_fixes",
+                *cmd_bazel_args,
                 "--",
                 *dwyu_report,
                 *verbosity,

--- a/test/apply_fixes/tool_cli/test_no_python_import_all_repositories.py
+++ b/test/apply_fixes/tool_cli/test_no_python_import_all_repositories.py
@@ -1,0 +1,21 @@
+from test.apply_fixes.test_case import TestCaseBase
+from test.support.result import Result, Success
+
+
+class TestCase(TestCaseBase):
+    @property
+    def test_target(self) -> str:
+        return "//tool_cli/workspace:binary"
+
+    def execute_test_logic(self) -> Result:
+        self._create_reports(aspect="//tool_cli/workspace:aspect.bzl%default_aspect")
+
+        self._run_automatic_fix(
+            bazel_args=["--@rules_python//python/config_settings:experimental_python_import_all_repositories=false"],
+            extra_args=["--fix-unused"],
+        )
+
+        target_deps = self._get_target_deps(self.test_target)
+        if (expected := set()) != target_deps:
+            return self._make_unexpected_deps_error(expected_deps=expected, actual_deps=target_deps)
+        return Success()

--- a/test/aspect/execute_tests.py
+++ b/test/aspect/execute_tests.py
@@ -33,8 +33,6 @@ TESTED_VERSIONS = [
 VERSION_SPECIFIC_ARGS = {
     # Reduce noise in test logs
     "--check_direct_dependencies=off": CompatibleVersions(),
-    # Experimental changes we want to be compatible for
-    "--experimental_python_import_all_repositories=false": CompatibleVersions(),
     # Preparation for incompatible changes
     "--incompatible_config_setting_private_default_visibility": CompatibleVersions(),
     "--incompatible_disable_target_provider_fields": CompatibleVersions(),


### PR DESCRIPTION
Testing this for the aspect is superfluous, now that the aspect no longer utilizes Python.

While we still support using this flag, we want to explicitly test its default value as default test setup. We test setting it to false via a dedicated integration test.