### PR TITLE
fix(aspect): Consistent hashing

### DIFF
--- a/dwyu/cc/aspect/dwyu.bzl
+++ b/dwyu/cc/aspect/dwyu.bzl
@@ -111,7 +111,7 @@ def _process_dependencies(ctx, target, deps):
     return [_process_target(
         ctx,
         target = dep,
-        output_path = "{}_processed_dep_{}.json".format(target.label.name, hash(str(dep.label))),
+        output_path = "{}_processed_dep_{}.json".format(target.label.name, _hash(str(dep.label))),
         is_target_under_inspection = False,
     ) for dep in deps]
 


### PR DESCRIPTION
We should use a consistent hashing scheme and not 2 different ones. Also, we don't want negative numbers as file paths, even if they should work on most systems.