### PR TITLE
feat(aspect): Allow controlling the behavior via tags

### DIFF
--- a/docs/api/dwyu_aspect.md
+++ b/docs/api/dwyu_aspect.md
@@ -16,14 +16,26 @@ dwyu_cc_aspect_factory(<a href="#dwyu_cc_aspect_factory-analysis_ignores_private
                        <a href="#dwyu_cc_aspect_factory-verbose">verbose</a>)
 </pre>
 
-Create a "**D**epend on **W**hat **Y**ou **U**se" (DWYU) aspect.
+Create and configure a "**D**epend on **W**hat **Y**ou **U**se" (DWYU) aspect.
 
-Use the factory in a `.bzl` file to instantiate a DWYU aspect:
-```starlark
-load("@depend_on_what_you_use//dwyu/cc:defs.bzl", "dwyu_cc_aspect_factory")
+You might have targets which require different DWYU settings than the ones set by you with the aspect factory.
+If this is the case for a separate part of your project, an easy solution can be to create a second aspect instance with different settings and use that for the targets in question.
+However, if the issue is with individual targets, you can also use the following tags to override the DWYU settings for those specific targets.
+Using tags to control the DWYU behavior is demonstrated in the [configuration_via_tags example](/examples/configuration_via_tags).<br>
+The detailed description for the features controlled by these tags can be found below in the documentation of the aspect factory parameters.
+If a tag sets a single value attribute, the tag value will override the value set by the aspect factory or via `--aspects_parameters`.
+If a tag sets a list attribute, the tag value will be appended to the list set by the aspect factory.
 
-your_dwyu_aspect = dwyu_cc_aspect_factory(<aspect_options>)
-```
+| Tag | Description |
+|---|---|
+| `dwyu:skip`                                            | Do not perform any DWYU analysis. |
+| `dwyu:ignore_private_headers_from_deps=[True\|False]` | Control whether to consider private headers from the `srcs` attribute of dependencies. |
+| `dwyu:optimize_impl_deps=[True\|False]`               | Control optimizing implementation dependencies. |
+| `dwyu:report_missing_direct_deps=[True\|False]`       | Control reporting missing direct dependencies. |
+| `dwyu:report_unused_deps=[True\|False]`               | Control reporting unused dependencies. |
+| `dwyu:ignore_include=<include>`                        | Ignore the specified include for the _missing direct dependencies_ check. Provide without quoting (aka `<` or `"`). Does not support setting patterns. Multiple uses are accumulated. |
+| `dwyu:ignore_unused_dep=<dep>`                         | Ignore the specified dependency for the _unused dependencies_ check. Has to use the canonical repo name. The examples show an elegant way to do this. Multiple uses are accumulated. |
+| `dwyu:preprocessing_mode=<mode>`                       | Control the preprocessing mode. |
 
 
 **PARAMETERS**
@@ -41,7 +53,7 @@ your_dwyu_aspect = dwyu_cc_aspect_factory(<aspect_options>)
 | <a id="dwyu_cc_aspect_factory-recursive"></a>recursive |  By default, the DWYU aspect analyzes only the target it is being applied to. You can change this to recursively analyzing dependencies following the `deps` and `implementation_deps` attributes by setting this to True.<br> This feature is demonstrated in the [recursion example](/examples/recursion).   |  `False` |
 | <a id="dwyu_cc_aspect_factory-skip_external_targets"></a>skip_external_targets |  Sometimes external dependencies are not our under control and thus analyzing them is of little value. If this flag is True, DWYU will automatically skip all targets from external workspaces. This can be useful in combination with the recursive analysis mode.<br> This feature is demonstrated in the [skipping_targets example](/examples/skipping_targets).   |  `False` |
 | <a id="dwyu_cc_aspect_factory-skip_toolchain_features"></a>skip_toolchain_features |  A list of C++ toolchain feature strings that control when the DWYU analysis is skipped. When a feature name is prefixed with `-` (e.g. `-layering_check`), the analysis is skipped if that feature is **disabled**. When a feature name has no prefix (e.g. `some_feature`), the analysis is skipped if that feature is **enabled**. This allows gating DWYU on the state of C++ toolchain features configured via the standard `features` attribute.<br> Please note, this is based on the features the active toolchain understands and not string comparison done with the `features` attribute values. Meaning, changing the toolchain can change the skipping behavior, even if the `features` attributes of your cc_* targets remain constant.   |  `[]` |
-| <a id="dwyu_cc_aspect_factory-skipped_tags"></a>skipped_tags |  Do not execute the DWYU analysis on targets with at least one of those tags. By default skips the analysis for targets tagged with 'no-dwyu'.<br> This feature is demonstrated in the [skipping_targets example](/examples/skipping_targets).   |  `["no-dwyu"]` |
+| <a id="dwyu_cc_aspect_factory-skipped_tags"></a>skipped_tags |  Do not execute the DWYU analysis on targets with at least one of those tags. By default skips the analysis for targets tagged with 'no-dwyu'.<br> This feature is demonstrated in the [skipping_targets example](/examples/skipping_targets).   |  `["no-dwyu", "dwyu:skip"]` |
 | <a id="dwyu_cc_aspect_factory-target_mapping"></a>target_mapping |  Accepts a [dwyu_make_cc_info_mapping](/docs/api/cc_info_mapping.md) target. Allows virtually combining targets regarding which header can be provided by which dependency. For the full details see the `dwyu_make_cc_info_mapping` documentation.<br> This feature is demonstrated in the [target_mapping example](/examples/target_mapping).   |  `None` |
 | <a id="dwyu_cc_aspect_factory-verbose"></a>verbose |  If `True`, print debugging information about the individual DWYU actions.<br> This flag can also be controlled in a Bazel config or on the command line via `--aspects_parameters=dwyu_verbose=[True\|False]`.   |  `False` |
 

--- a/dwyu/cc/aspect/dwyu.bzl
+++ b/dwyu/cc/aspect/dwyu.bzl
@@ -3,7 +3,7 @@ load("@rules_cc//cc:find_cc_toolchain.bzl", "find_cc_toolchain")
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load("//dwyu/cc/cc_info_mapping:providers.bzl", "DwyuCcInfoMappingInfo")
-load("//dwyu/private:utils.bzl", "make_param_file_args")
+load("//dwyu/private:utils.bzl", "make_param_file_args", "string_to_bool")
 
 # Map of '-std=c++XX' to the corresponding standard version
 # Source for this mapping: https://gcc.gnu.org/onlinedocs/gcc/C-Dialect-Options.html#index-std-1
@@ -28,6 +28,8 @@ _CPLUSPLUS_VERSIONS_MAP = {
     "98": "199711",
 }
 
+PREPROCESSOR_MODES = ["full", "ignore_system_includes", "fast"]
+
 def _is_verbose(ctx):
     return ctx.attr.dwyu_verbose
 
@@ -39,6 +41,49 @@ def _hash(value):
     Using '%x' prevents negative numbers being returned
     """
     return "%x" % hash(value)
+
+def _make_dwyu_config(ctx):
+    """
+    Some values can be configured by tags on top of the aspect factory attributes.
+    For those values we have to combine the factory and tag configuration.
+    For single state values the tag overwrites the factory config. For list values the tag adds to the factory config.
+    """
+
+    analysis_ignores_private_headers_from_deps = ctx.attr.dwyu_analysis_ignores_private_headers_from_deps
+    analysis_optimizes_impl_deps = ctx.attr.dwyu_analysis_optimizes_impl_deps
+    analysis_reports_missing_direct_deps = ctx.attr.dwyu_analysis_reports_missing_direct_deps
+    analysis_reports_unused_deps = ctx.attr.dwyu_analysis_reports_unused_deps
+    preprocessing_mode = ctx.attr._preprocessing_mode
+    ignored_includes = []
+    ignored_unused_deps = ctx.attr._ignored_unused_deps[:]
+
+    for tag in ctx.rule.attr.tags:
+        if tag.startswith("dwyu:ignore_private_headers_from_deps="):
+            analysis_ignores_private_headers_from_deps = string_to_bool(tag.split("=", 1)[1])
+        elif tag.startswith("dwyu:optimize_impl_deps="):
+            analysis_optimizes_impl_deps = string_to_bool(tag.split("=", 1)[1])
+        elif tag.startswith("dwyu:report_missing_direct_deps="):
+            analysis_reports_missing_direct_deps = string_to_bool(tag.split("=", 1)[1])
+        elif tag.startswith("dwyu:report_unused_deps="):
+            analysis_reports_unused_deps = string_to_bool(tag.split("=", 1)[1])
+        elif tag.startswith("dwyu:preprocessing_mode="):
+            preprocessing_mode = tag.split("=", 1)[1]
+            if preprocessing_mode not in PREPROCESSOR_MODES:
+                fail("Provided invalid value '{}' for 'dwyu:preprocessing_mode' tag. Supported values are {}".format(preprocessing_mode, PREPROCESSOR_MODES))
+        elif tag.startswith("dwyu:ignore_include="):
+            ignored_includes.append(tag.split("=", 1)[1])
+        elif tag.startswith("dwyu:ignore_unused_dep="):
+            ignored_unused_deps.append(tag.split("=", 1)[1])
+
+    return struct(
+        extra_ignored_includes = ignored_includes,
+        ignored_unused_deps = ignored_unused_deps,
+        preprocessing_mode = preprocessing_mode,
+        ignore_private_headers_from_deps = analysis_ignores_private_headers_from_deps,
+        optimize_impl_deps = analysis_optimizes_impl_deps,
+        report_missing_direct_deps = analysis_reports_missing_direct_deps,
+        report_unused_deps = analysis_reports_unused_deps,
+    )
 
 def _get_target_sources(rule):
     public_files = []
@@ -81,11 +126,11 @@ def _get_includes(ctx, target_cc):
 
     return includes, quote_includes, external_includes, system_includes
 
-def _process_target(ctx, target, output_path, is_target_under_inspection):
+def _process_target(ctx, target, config, output_path, is_target_under_inspection):
     processing_output = ctx.actions.declare_file(output_path)
     header_files = _get_relevant_header(
         target_cc = target.cc_info.compilation_context,
-        include_private_headers = is_target_under_inspection or not ctx.attr.dwyu_analysis_ignores_private_headers_from_deps,
+        include_private_headers = is_target_under_inspection or not config.ignore_private_headers_from_deps,
     )
 
     args = make_param_file_args(ctx)
@@ -107,10 +152,11 @@ def _process_target(ctx, target, output_path, is_target_under_inspection):
 
     return processing_output
 
-def _process_dependencies(ctx, target, deps):
+def _process_dependencies(ctx, target, config, deps):
     return [_process_target(
         ctx,
         target = dep,
+        config = config,
         output_path = "{}_processed_dep_{}.json".format(target.label.name, _hash(str(dep.label))),
         is_target_under_inspection = False,
     ) for dep in deps]
@@ -272,12 +318,12 @@ def _preprocess_deps(ctx):
 
     return target_deps, target_impl_deps
 
-def _do_ensure_private_deps(ctx):
+def _do_ensure_private_deps(ctx, config):
     """
     The implementation_deps feature is only meaningful and available for cc_library, where in contrast to cc_binary
     and cc_test a separation between public and private files exists.
     """
-    return ctx.rule.kind == "cc_library" and ctx.attr.dwyu_analysis_optimizes_impl_deps
+    return ctx.rule.kind == "cc_library" and config.optimize_impl_deps
 
 def _dywu_results_from_deps(deps):
     """
@@ -298,7 +344,7 @@ def _gather_transitive_reports(ctx):
             reports.extend(_dywu_results_from_deps(ctx.rule.attr.implementation_deps))
     return reports
 
-def _extract_includes_from_files(ctx, target, files, defines, cc_toolchain, attr_prefix):
+def _extract_includes_from_files(ctx, config, target, files, defines, cc_toolchain, attr_prefix):
     """
     For each given file perform a preprocessing step to find all relevant include statements
     """
@@ -333,7 +379,7 @@ def _extract_includes_from_files(ctx, target, files, defines, cc_toolchain, attr
         # The source files could be a TreeArtifact! Thus, process each file as list, although we want to process the individual source files in parallel by default.
         args = make_param_file_args(ctx)
         args.add_all("--files", [file])
-        args.add("--mode", ctx.attr._preprocessing_mode)
+        args.add("--mode", config.preprocessing_mode)
         args.add_all("--include_paths", include_paths)
         args.add_all("--system_include_paths", system_include_paths)
         args.add_all("--defines", defines)
@@ -406,10 +452,13 @@ def dwyu_cc_aspect_impl(target, ctx):
     if not public_files and not private_files:
         return []
 
-    defines = [] if ctx.attr._preprocessing_mode == "fast" else _parse_compiler_command(ctx, target[CcInfo].compilation_context, cc_toolchain, feature_configuration)
+    config = _make_dwyu_config(ctx)
+
+    defines = [] if config.preprocessing_mode == "fast" else _parse_compiler_command(ctx, target[CcInfo].compilation_context, cc_toolchain, feature_configuration)
     processed_target = _process_target(
         ctx,
         target = struct(label = target.label, cc_info = target[CcInfo]),
+        config = config,
         output_path = "{}_processed_target_under_inspection.json".format(target.label.name),
         is_target_under_inspection = True,
     )
@@ -418,13 +467,29 @@ def dwyu_cc_aspect_impl(target, ctx):
 
     # TODO Investigate if we can prevent running this multiple times for the same dep if multiple
     #      target_under_inspection have the same dependency
-    processed_deps = _process_dependencies(ctx, target = target, deps = target_deps)
-    processed_impl_deps = _process_dependencies(ctx, target = target, deps = target_impl_deps)
+    processed_deps = _process_dependencies(ctx, target = target, config = config, deps = target_deps)
+    processed_impl_deps = _process_dependencies(ctx, target = target, config = config, deps = target_impl_deps)
 
     report_file = ctx.actions.declare_file("{}_dwyu_report.json".format(target.label.name))
 
-    preprocessed_public_files = _extract_includes_from_files(ctx = ctx, target = target, files = public_files, defines = defines, cc_toolchain = cc_toolchain, attr_prefix = "pub")
-    preprocessed_private_files = _extract_includes_from_files(ctx = ctx, target = target, files = private_files, defines = defines, cc_toolchain = cc_toolchain, attr_prefix = "priv")
+    preprocessed_public_files = _extract_includes_from_files(
+        ctx = ctx,
+        config = config,
+        target = target,
+        files = public_files,
+        defines = defines,
+        cc_toolchain = cc_toolchain,
+        attr_prefix = "pub",
+    )
+    preprocessed_private_files = _extract_includes_from_files(
+        ctx = ctx,
+        config = config,
+        target = target,
+        files = private_files,
+        defines = defines,
+        cc_toolchain = cc_toolchain,
+        attr_prefix = "priv",
+    )
 
     args = make_param_file_args(ctx)
     args.add("--output", report_file)
@@ -436,12 +501,13 @@ def dwyu_cc_aspect_impl(target, ctx):
     args.add_all("--implementation_deps", processed_impl_deps, omit_if_empty = False)
     if ctx.attr._ignored_includes:
         args.add("--ignored_includes_config", ctx.files._ignored_includes[0])
-    args.add_all("--ignored_unused_deps", ctx.attr._ignored_unused_deps, omit_if_empty = True)
-    if _do_ensure_private_deps(ctx):
+    args.add_all("--extra_ignored_includes", config.extra_ignored_includes, omit_if_empty = True)
+    args.add_all("--ignored_unused_deps", config.ignored_unused_deps, omit_if_empty = True)
+    if _do_ensure_private_deps(ctx, config):
         args.add("--optimize_implementation_deps")
-    if ctx.attr.dwyu_analysis_reports_missing_direct_deps:
+    if config.report_missing_direct_deps:
         args.add("--report_missing_direct_deps")
-    if ctx.attr.dwyu_analysis_reports_unused_deps:
+    if config.report_unused_deps:
         args.add("--report_unused_deps")
     if _is_verbose(ctx):
         args.add("--verbose")

--- a/dwyu/cc/aspect/factory.bzl
+++ b/dwyu/cc/aspect/factory.bzl
@@ -1,10 +1,12 @@
 load("@rules_cc//cc:find_cc_toolchain.bzl", "use_cc_toolchain")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load("//dwyu/cc/cc_info_mapping:providers.bzl", "DwyuCcInfoMappingInfo")
-load(":dwyu.bzl", "dwyu_cc_aspect_impl")
+load("//dwyu/private:utils.bzl", "unique_list")
+load(":dwyu.bzl", "PREPROCESSOR_MODES", "dwyu_cc_aspect_impl")
 
-_DEFAULT_SKIPPED_TAGS = ["no-dwyu"]
-_PREPROCESSOR_MODES = ["full", "ignore_system_includes", "fast"]
+_LEGACY_SKIPPED_TAGS = ["no-dwyu"]
+_MANDATORY_SKIPPED_TAGS = ["dwyu:skip"]
+_DEFAULT_SKIPPED_TAGS = _LEGACY_SKIPPED_TAGS + _MANDATORY_SKIPPED_TAGS
 
 def dwyu_cc_aspect_factory(
         analysis_ignores_private_headers_from_deps = True,
@@ -21,22 +23,34 @@ def dwyu_cc_aspect_factory(
         target_mapping = None,
         verbose = False):
     """
-    Create a "**D**epend on **W**hat **Y**ou **U**se" (DWYU) aspect.
+    Create and configure a "**D**epend on **W**hat **Y**ou **U**se" (DWYU) aspect.
 
-    Use the factory in a `.bzl` file to instantiate a DWYU aspect:
-    ```starlark
-    load("@depend_on_what_you_use//dwyu/cc:defs.bzl", "dwyu_cc_aspect_factory")
+    You might have targets which require different DWYU settings than the ones set by you with the aspect factory.
+    If this is the case for a separate part of your project, an easy solution can be to create a second aspect instance with different settings and use that for the targets in question.
+    However, if the issue is with individual targets, you can also use the following tags to override the DWYU settings for those specific targets.
+    Using tags to control the DWYU behavior is demonstrated in the [configuration_via_tags example](/examples/configuration_via_tags).<br>
+    The detailed description for the features controlled by these tags can be found below in the documentation of the aspect factory parameters.
+    If a tag sets a single value attribute, the tag value will override the value set by the aspect factory or via `--aspects_parameters`.
+    If a tag sets a list attribute, the tag value will be appended to the list set by the aspect factory.
 
-    your_dwyu_aspect = dwyu_cc_aspect_factory(<aspect_options>)
-    ```
+    | Tag | Description |
+    |---|---|
+    | `dwyu:skip`                                            | Do not perform any DWYU analysis. |
+    | `dwyu:ignore_private_headers_from_deps=[True\\|False]` | Control whether to consider private headers from the `srcs` attribute of dependencies. |
+    | `dwyu:optimize_impl_deps=[True\\|False]`               | Control optimizing implementation dependencies. |
+    | `dwyu:report_missing_direct_deps=[True\\|False]`       | Control reporting missing direct dependencies. |
+    | `dwyu:report_unused_deps=[True\\|False]`               | Control reporting unused dependencies. |
+    | `dwyu:ignore_include=<include>`                        | Ignore the specified include for the _missing direct dependencies_ check. Provide without quoting (aka `<` or `"`). Does not support setting patterns. Multiple uses are accumulated. |
+    | `dwyu:ignore_unused_dep=<dep>`                         | Ignore the specified dependency for the _unused dependencies_ check. Has to use the canonical repo name. The examples show an elegant way to do this. Multiple uses are accumulated. |
+    | `dwyu:preprocessing_mode=<mode>`                       | Control the preprocessing mode. |
 
     Args:
         analysis_ignores_private_headers_from_deps: Setting this to `False` will allow headers listed in the `srcs` attributes of a dependency to fulfill the DWYU checks on top of those from the `hdrs` attribute.
-                                                   By default, DWYU uses only headers from the `hdrs` attribute.</br>
-                                                   Strictly speaking, using headers from the `srcs` attribute of a dependency is wrong, as they are an implementation detail of the dependency.
-                                                   However, Bazel does not enforce this and forwards those private headers to the compile step.
-                                                   Use this flag if you have code outside your control using private headers or simply are not interested in the distinction of public and private headers.</br>
-                                                   This flag can also be controlled in a Bazel config or on the command line via `--aspects_parameters=dwyu_analysis_ignores_private_headers_from_deps=[True|False]`.
+                                                    By default, DWYU uses only headers from the `hdrs` attribute.</br>
+                                                    Strictly speaking, using headers from the `srcs` attribute of a dependency is wrong, as they are an implementation detail of the dependency.
+                                                    However, Bazel does not enforce this and forwards those private headers to the compile step.
+                                                    Use this flag if you have code outside your control using private headers or simply are not interested in the distinction of public and private headers.</br>
+                                                    This flag can also be controlled in a Bazel config or on the command line via `--aspects_parameters=dwyu_analysis_ignores_private_headers_from_deps=[True|False]`.
 
         analysis_optimizes_impl_deps: Setting this to `True` will raise an error for `cc_library` targets where headers from a `deps` dependency are used only in private files.
                                       Such dependencies should be moved from `deps` to [implementation_deps](https://bazel.build/reference/be/c-cpp#cc_library.implementation_deps) to optimize the dependency graph of the project.<br>
@@ -125,11 +139,11 @@ def dwyu_cc_aspect_factory(
     if recursive:
         attr_aspects = ["implementation_deps", "deps"]
     aspect_ignored_includes = [ignored_includes] if ignored_includes else []
-    aspect_skipped_tags = _DEFAULT_SKIPPED_TAGS if skipped_tags == _DEFAULT_SKIPPED_TAGS else skipped_tags
+    aspect_skipped_tags = _DEFAULT_SKIPPED_TAGS if skipped_tags == _DEFAULT_SKIPPED_TAGS else unique_list(skipped_tags, _MANDATORY_SKIPPED_TAGS)
     aspect_target_mapping = [target_mapping] if target_mapping else []
 
-    if preprocessing_mode not in _PREPROCESSOR_MODES:
-        fail("Provided invalid value '{}' for 'preprocessing_mode'. Supported values are {}".format(preprocessing_mode, _PREPROCESSOR_MODES))
+    if preprocessing_mode not in PREPROCESSOR_MODES:
+        fail("Provided invalid value '{}' for 'preprocessing_mode'. Supported values are {}".format(preprocessing_mode, PREPROCESSOR_MODES))
 
     return aspect(
         implementation = dwyu_cc_aspect_impl,

--- a/dwyu/cc/aspect/private/analyze_includes/ignored_includes.cpp
+++ b/dwyu/cc/aspect/private/analyze_includes/ignored_includes.cpp
@@ -7,12 +7,14 @@
 
 #include <algorithm>
 #include <string>
+#include <tuple>
 #include <unordered_set>
 #include <vector>
 
 namespace dwyu {
 
-IgnoredIncludes getIgnoredIncludes(const std::string& ignored_includes_config) {
+IgnoredIncludes getIgnoredIncludes(const std::string& ignored_includes_config,
+                                   const std::vector<std::string>& extra_ignored_includes) {
     IgnoredIncludes ignored_includes{};
 
     constexpr bool no_error_on_missing_file = true;
@@ -24,6 +26,9 @@ IgnoredIncludes getIgnoredIncludes(const std::string& ignored_includes_config) {
         for (const auto& pattern : ignores_config["ignore_include_patterns"].get<std::vector<std::string>>()) {
             ignored_includes.include_patterns.emplace_back(pattern);
         }
+    }
+    for (const auto& include : extra_ignored_includes) {
+        std::ignore = ignored_includes.include_paths.insert(include);
     }
 
     return ignored_includes;

--- a/dwyu/cc/aspect/private/analyze_includes/ignored_includes.h
+++ b/dwyu/cc/aspect/private/analyze_includes/ignored_includes.h
@@ -18,7 +18,8 @@ struct IgnoredIncludes {
     std::vector<boost::regex> include_patterns{};
 };
 
-IgnoredIncludes getIgnoredIncludes(const std::string& ignored_includes_config);
+IgnoredIncludes getIgnoredIncludes(const std::string& ignored_includes_config,
+                                   const std::vector<std::string>& extra_ignored_includes);
 
 bool isIgnoredInclude(const std::string& include, const IgnoredIncludes& ignored_includes);
 

--- a/dwyu/cc/aspect/private/analyze_includes/main.cpp
+++ b/dwyu/cc/aspect/private/analyze_includes/main.cpp
@@ -25,6 +25,7 @@ struct ProgramOptions {
     std::vector<std::string> deps{};
     std::vector<std::string> implementation_deps{};
     std::string ignored_includes_config{};
+    std::vector<std::string> extra_ignored_includes{};
     std::vector<std::string> ignored_unused_deps{};
     bool optimize_implementation_deps{};
     bool report_missing_direct_deps{};
@@ -52,6 +53,8 @@ ProgramOptions parseProgramOptions(int argc, ProgramOptionsParser::ConstCharArra
     parser.addOptionList("--implementation_deps", options.implementation_deps);
     // Config file in json format specifying which include paths and patterns shall be ignored by the analysis
     parser.addOptionValue("--ignored_includes_config", options.ignored_includes_config);
+    // Include statements which shall be ignored on top of those specified via the config file
+    parser.addOptionList("--extra_ignored_includes", options.extra_ignored_includes);
     // List of dependency names which shall be ignored for the unused dependencies check
     parser.addOptionList("--ignored_unused_deps", options.ignored_unused_deps);
     // If this is checked, ensure all 'deps' are indeed used in at least one public file
@@ -86,7 +89,7 @@ int main_impl(const ProgramOptions& options) {
         std::cout << "\n";
     }
 
-    const auto ignored_includes = getIgnoredIncludes(options.ignored_includes_config);
+    const auto ignored_includes = getIgnoredIncludes(options.ignored_includes_config, options.extra_ignored_includes);
     auto system_under_inspection =
         getSystemUnderInspection(options.target_under_inspection_info, options.deps, options.implementation_deps);
     auto public_includes = getIncludeStatements(options.preprocessed_public_files, ignored_includes);

--- a/dwyu/cc/aspect/private/analyze_includes/test/ignored_includes_test.cpp
+++ b/dwyu/cc/aspect/private/analyze_includes/test/ignored_includes_test.cpp
@@ -4,11 +4,14 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <string>
+#include <vector>
+
 namespace dwyu {
 namespace {
 
 TEST(GetIgnoredIncludes, GivenNoInputReturnEmptyIgnoredIncludes) {
-    const auto ignored_includes = getIgnoredIncludes("");
+    const auto ignored_includes = getIgnoredIncludes("", {});
 
     EXPECT_TRUE(ignored_includes.include_paths.empty());
     EXPECT_TRUE(ignored_includes.include_patterns.empty());
@@ -16,7 +19,7 @@ TEST(GetIgnoredIncludes, GivenNoInputReturnEmptyIgnoredIncludes) {
 
 TEST(GetIgnoredIncludes, GivenEmptyInputReturnEmptyIgnoredIncludes) {
     const auto ignored_includes =
-        getIgnoredIncludes("dwyu/cc/aspect/private/analyze_includes/test/data/ignored_includes_empty.json");
+        getIgnoredIncludes("dwyu/cc/aspect/private/analyze_includes/test/data/ignored_includes_empty.json", {});
 
     EXPECT_TRUE(ignored_includes.include_paths.empty());
     EXPECT_TRUE(ignored_includes.include_patterns.empty());
@@ -24,9 +27,21 @@ TEST(GetIgnoredIncludes, GivenEmptyInputReturnEmptyIgnoredIncludes) {
 
 TEST(GetIgnoredIncludes, ReadIgnoredIncludesCorrectlyFromFile) {
     const auto ignored_includes =
-        getIgnoredIncludes("dwyu/cc/aspect/private/analyze_includes/test/data/ignored_includes.json");
+        getIgnoredIncludes("dwyu/cc/aspect/private/analyze_includes/test/data/ignored_includes.json", {});
 
     EXPECT_THAT(ignored_includes.include_paths, testing::UnorderedElementsAre("foo", "bar"));
+
+    EXPECT_THAT(ignored_includes.include_patterns,
+                testing::UnorderedElementsAre(boost::regex{"foo/.*"}, boost::regex{"bar/.*"}));
+}
+
+TEST(GetIgnoredIncludes, ReadIgnoredIncludesCorrectlyFromFileWithExtraIncludes) {
+    // duplicate 'foo' to ensure that the extra includes are merged correctly with the config file
+    const std::vector<std::string> extra_ignored_includes = {"foo", "extra/include.h"};
+    const auto ignored_includes = getIgnoredIncludes(
+        "dwyu/cc/aspect/private/analyze_includes/test/data/ignored_includes.json", extra_ignored_includes);
+
+    EXPECT_THAT(ignored_includes.include_paths, testing::UnorderedElementsAre("foo", "bar", "extra/include.h"));
 
     EXPECT_THAT(ignored_includes.include_patterns,
                 testing::UnorderedElementsAre(boost::regex{"foo/.*"}, boost::regex{"bar/.*"}));

--- a/dwyu/private/test/utils_test.bzl
+++ b/dwyu/private/test/utils_test.bzl
@@ -1,5 +1,5 @@
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
-load("//dwyu/private:utils.bzl", "label_to_name")
+load("//dwyu/private:utils.bzl", "label_to_name", "string_to_bool", "unique_list")
 
 def _label_to_name_test_impl(ctx):
     env = unittest.begin(ctx)
@@ -14,8 +14,54 @@ def _label_to_name_test_impl(ctx):
 
 label_to_name_test = unittest.make(_label_to_name_test_impl)
 
+def _unique_list_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    # Disjoint lists are simply combined
+    asserts.equals(env, [1, 2, 3, 4], unique_list([1, 2], [3, 4]))
+
+    # Duplicates within the combined result are removed, first occurrence is kept
+    asserts.equals(env, [1, 2, 3], unique_list([1, 2], [2, 3]))
+
+    # Duplicates spanning both lists are removed
+    asserts.equals(env, [1, 2, 3], unique_list([1, 2, 3], [1, 2, 3]))
+
+    # Empty inputs
+    asserts.equals(env, [], unique_list([], []))
+    asserts.equals(env, [1, 2], unique_list([1, 2], []))
+    asserts.equals(env, [1, 2], unique_list([], [1, 2]))
+
+    return unittest.end(env)
+
+unique_list_test = unittest.make(_unique_list_test_impl)
+
+def _string_to_bool_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    # Truthy values
+    asserts.equals(env, True, string_to_bool("true"))
+    asserts.equals(env, True, string_to_bool("1"))
+    asserts.equals(env, True, string_to_bool("yes"))
+
+    # Falsy values
+    asserts.equals(env, False, string_to_bool("false"))
+    asserts.equals(env, False, string_to_bool("0"))
+    asserts.equals(env, False, string_to_bool("no"))
+
+    # Case-insensitive
+    asserts.equals(env, True, string_to_bool("True"))
+    asserts.equals(env, True, string_to_bool("TRUE"))
+    asserts.equals(env, False, string_to_bool("False"))
+    asserts.equals(env, False, string_to_bool("FALSE"))
+
+    return unittest.end(env)
+
+string_to_bool_test = unittest.make(_string_to_bool_test_impl)
+
 def utils_test_suite(name):
     unittest.suite(
         name,
         label_to_name_test,
+        string_to_bool_test,
+        unique_list_test,
     )

--- a/dwyu/private/utils.bzl
+++ b/dwyu/private/utils.bzl
@@ -13,3 +13,17 @@ def make_param_file_args(ctx):
     args.use_param_file("--param_file=%s")
 
     return args
+
+def string_to_bool(value):
+    if value.lower() in ["true", "1", "yes"]:
+        return True
+    elif value.lower() in ["false", "0", "no"]:
+        return False
+    else:
+        fail("Invalid boolean value: {}".format(value))
+
+def unique_list(list_a, list_b):
+    """
+    Combine two lists and return a new list without duplicates, preserving order of first occurrence.
+    """
+    return {x: None for x in list_a + list_b}.keys()

--- a/examples/configuration_via_tags/BUILD
+++ b/examples/configuration_via_tags/BUILD
@@ -1,0 +1,53 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load(":to_canonical.bzl", "to_canonical")
+
+# Those are some examples for using tags to control the DWYU behavior.
+# Not all options are demonstrated, but just a select few.
+# For a complete list of tags see the aspect documentation.
+
+# Specifies an unused dependency, which would fail the DWYU analysis
+cc_library(
+    name = "skipped_target",
+    hdrs = ["lib_1.h"],
+    tags = ["dwyu:skip"],
+    deps = [":foo"],
+)
+
+# We use DWYU on this target, but tell DWYU to ignore a specific unused dependency
+cc_library(
+    name = "exception_for_unused_deps",
+    hdrs = ["lib_1.h"],
+    tags = ["dwyu:ignore_unused_dep={}".format(to_canonical(":foo"))],
+    deps = [":foo"],
+)
+
+# If the problem with the unused dependency check is not with specific targets, but a general one, we can disable the whole check
+cc_library(
+    name = "disable_check_for_unused_deps",
+    hdrs = ["lib_1.h"],
+    tags = ["dwyu:report_unused_deps=False"],
+    deps = [":foo"],
+)
+
+# Using a header from a transitive dependency would fail, unless we tell DWYU to ignore the inclusion of that header
+cc_library(
+    name = "exception_for_include_of_transitive_dependency",
+    hdrs = ["lib_2.h"],
+    tags = ["dwyu:ignore_include=configuration_via_tags/bar.h"],
+    deps = [":foo"],
+)
+
+#
+# Support targets
+#
+
+cc_library(
+    name = "foo",
+    hdrs = ["foo.h"],
+    deps = [":bar"],
+)
+
+cc_library(
+    name = "bar",
+    hdrs = ["bar.h"],
+)

--- a/examples/configuration_via_tags/README.md
+++ b/examples/configuration_via_tags/README.md
@@ -1,0 +1,13 @@
+Demonstrate how one can modify the DWYU behavior for individual targets by overwriting the DWYU aspect settings via tags.
+
+Under normal circumstances, the demonstration targets would fail the DWYU analysis.
+We configure them with tags to not fail the DWYU analysis performed on this package.
+
+Execute the following to see that the DWYU analysis is green, despite the various issues if the targets (see comments int he `BUILD` file).
+
+```shell
+bazel build --config=dwyu //configuration_via_tags/...
+```
+
+Please note, this technique is intended to specify individual exceptions.
+If you want to change the DWYU behavior globally, do s via the aspect factory parameters.

--- a/examples/configuration_via_tags/foo.h
+++ b/examples/configuration_via_tags/foo.h
@@ -1,0 +1,1 @@
+#include "configuration_via_tags/bar.h"

--- a/examples/configuration_via_tags/lib_2.h
+++ b/examples/configuration_via_tags/lib_2.h
@@ -1,0 +1,2 @@
+#include "configuration_via_tags/bar.h"
+#include "configuration_via_tags/foo.h"

--- a/examples/configuration_via_tags/to_canonical.bzl
+++ b/examples/configuration_via_tags/to_canonical.bzl
@@ -1,0 +1,9 @@
+def to_canonical(apparent_name):
+    """
+    Convert a target using the apparent repo name to one using the canonical repo name.
+    This has to be a macro, since the 'Label' function is not available in BUILD files.
+
+    Please note, this macro has to live in the client workspace.
+    Reusing it from another workspace will not work, as then the 'Label' function will resolve relative to the workspace from which you load the macro.
+    """
+    return str(Label(apparent_name))

--- a/examples/test.py
+++ b/examples/test.py
@@ -42,6 +42,10 @@ EXAMPLES = [
         expected_success=False,
     ),
     Example(
+        build_cmd="--config=dwyu //configuration_via_tags/...",
+        expected_success=True,
+    ),
+    Example(
         build_cmd="--config=dwyu //define_macros:main",
         expected_success=False,
     ),

--- a/test/aspect/allow_private_headers_from_deps/BUILD
+++ b/test/aspect/allow_private_headers_from_deps/BUILD
@@ -9,15 +9,29 @@ cc_library(
 )
 
 cc_library(
+    name = "allow_private_headers_from_deps_via_tag",
+    srcs = ["use_private_headers_from_deps.cpp"],
+    hdrs = ["use_private_headers_from_deps.h"],
+    implementation_deps = [":dep_b"],
+    tags = ["dwyu:ignore_private_headers_from_deps=False"],
+    deps = [":dep_a"],
+)
+
+cc_library(
+    name = "forbid_private_headers_from_deps_via_tag",
+    srcs = ["use_private_headers_from_deps.cpp"],
+    hdrs = ["use_private_headers_from_deps.h"],
+    implementation_deps = [":dep_b"],
+    tags = ["dwyu:ignore_private_headers_from_deps=True"],
+    deps = [":dep_a"],
+)
+
+cc_library(
     name = "dep_a",
     srcs = ["private_a.h"],
-    # without a public header we cannot trigger the 'unused dependency' error, since dependencies offering no usable headers are pruned early int he analysis
-    hdrs = ["dep.h"],
 )
 
 cc_library(
     name = "dep_b",
     srcs = ["private_b.h"],
-    # without a public header we cannot trigger the 'unused dependency' error, since dependencies offering no usable headers are pruned early int he analysis
-    hdrs = ["dep.h"],
 )

--- a/test/aspect/allow_private_headers_from_deps/test_tag_false.py
+++ b/test/aspect/allow_private_headers_from_deps/test_tag_false.py
@@ -1,0 +1,14 @@
+from expected_result import ExpectedSuccess
+from test_case import TestCaseBase
+
+from test.support.result import Result
+
+
+class TestCase(TestCaseBase):
+    def execute_test_logic(self) -> Result:
+        actual = self._run_dwyu(
+            target="//allow_private_headers_from_deps:allow_private_headers_from_deps_via_tag",
+            aspect=self.default_aspect,
+        )
+
+        return self._check_result(actual=actual, expected=ExpectedSuccess())

--- a/test/aspect/allow_private_headers_from_deps/test_tag_true.py
+++ b/test/aspect/allow_private_headers_from_deps/test_tag_true.py
@@ -9,7 +9,7 @@ class TestCase(TestCaseBase):
         # We are not seeing unused dependency errors because DWYU thinks the dependencies offer not headers at al and thus prunes them early in the analysis.
         expected = ExpectedFailure(
             ExpectedDwyuFailure(
-                target="//allow_private_headers_from_deps:use_private_headers_from_deps",
+                target="//allow_private_headers_from_deps:forbid_private_headers_from_deps_via_tag",
                 invalid_includes={
                     "allow_private_headers_from_deps/use_private_headers_from_deps.h": [
                         "allow_private_headers_from_deps/private_a.h"
@@ -21,7 +21,9 @@ class TestCase(TestCaseBase):
             )
         )
         actual = self._run_dwyu(
-            target="//allow_private_headers_from_deps:use_private_headers_from_deps", aspect=self.default_aspect
+            target="//allow_private_headers_from_deps:forbid_private_headers_from_deps_via_tag",
+            # Use an aspect allowing private headers from deps to show we can overrule the global setting via a tag on the target under inspection
+            aspect="//allow_private_headers_from_deps:aspect.bzl%dwyu_with_priv_hdrs",
         )
 
         return self._check_result(actual=actual, expected=expected)

--- a/test/aspect/ignore_includes/BUILD
+++ b/test/aspect/ignore_includes/BUILD
@@ -12,6 +12,16 @@ cc_library(
     deps = ["//ignore_includes/support:direct_dep"],
 )
 
+cc_library(
+    name = "use_multiple_headers_ignored_via_tag",
+    hdrs = ["use_multiple_ignored_headers.h"],
+    tags = [
+        "dwyu:ignore_include=support/some_header.h",
+        "dwyu:ignore_include=support/some_other_header.h",
+    ],
+    deps = ["//ignore_includes/support:direct_dep"],
+)
+
 # Has multiple invalid includes, which do however not cause an error due to them matching the ignored patterns
 cc_library(
     name = "use_ignored_patterns",

--- a/test/aspect/ignore_includes/test_custom_ignore_include_paths_via_tag.py
+++ b/test/aspect/ignore_includes/test_custom_ignore_include_paths_via_tag.py
@@ -1,0 +1,13 @@
+from expected_result import ExpectedSuccess
+from test_case import TestCaseBase
+
+from test.support.result import Result
+
+
+class TestCase(TestCaseBase):
+    def execute_test_logic(self) -> Result:
+        actual = self._run_dwyu(
+            target="//ignore_includes:use_multiple_headers_ignored_via_tag", aspect=self.default_aspect
+        )
+
+        return self._check_result(actual=actual, expected=ExpectedSuccess())

--- a/test/aspect/ignore_unused_deps/BUILD
+++ b/test/aspect/ignore_unused_deps/BUILD
@@ -1,4 +1,5 @@
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load(":to_canonical.bzl", "to_canonical")
 
 cc_library(
     name = "foo",
@@ -10,5 +11,17 @@ cc_library(
     srcs = ["lib.cpp"],
     hdrs = ["lib.h"],
     implementation_deps = ["@ignore_unused_deps_test_repo//:ext"],
+    deps = [":foo"],
+)
+
+cc_library(
+    name = "lib_with_unused_deps_ignored_by_tag",
+    srcs = ["lib.cpp"],
+    hdrs = ["lib.h"],
+    implementation_deps = ["@ignore_unused_deps_test_repo//:ext"],
+    tags = [
+        "dwyu:ignore_unused_dep={}".format(to_canonical("//ignore_unused_deps:foo")),
+        "dwyu:ignore_unused_dep={}".format(to_canonical("@ignore_unused_deps_test_repo//:ext")),
+    ],
     deps = [":foo"],
 )

--- a/test/aspect/ignore_unused_deps/test_ignore_unused_deps_via_tags.py
+++ b/test/aspect/ignore_unused_deps/test_ignore_unused_deps_via_tags.py
@@ -1,0 +1,13 @@
+from expected_result import ExpectedSuccess
+from test_case import TestCaseBase
+
+from test.support.result import Result
+
+
+class TestCase(TestCaseBase):
+    def execute_test_logic(self) -> Result:
+        actual = self._run_dwyu(
+            target="//ignore_unused_deps:lib_with_unused_deps_ignored_by_tag", aspect=self.default_aspect
+        )
+
+        return self._check_result(actual=actual, expected=ExpectedSuccess())

--- a/test/aspect/ignore_unused_deps/to_canonical.bzl
+++ b/test/aspect/ignore_unused_deps/to_canonical.bzl
@@ -1,0 +1,5 @@
+def to_canonical(target):
+    """
+    We can't use the 'Label()' constructor in BUILD files without the indirection through a macro.
+    """
+    return str(Label(target))

--- a/test/aspect/implementation_deps/BUILD
+++ b/test/aspect/implementation_deps/BUILD
@@ -21,6 +21,28 @@ cc_library(
 )
 
 cc_library(
+    name = "superfluous_public_dep_with_tag_opt_in",
+    srcs = ["use_libs.cpp"],
+    hdrs = ["use_libs.h"],
+    tags = ["dwyu:optimize_impl_deps=True"],
+    deps = [
+        "//implementation_deps/support:lib_a",
+        "//implementation_deps/support:lib_b",
+    ],
+)
+
+cc_library(
+    name = "superfluous_public_dep_with_tag_opt_out",
+    srcs = ["use_libs.cpp"],
+    hdrs = ["use_libs.h"],
+    tags = ["dwyu:optimize_impl_deps=False"],
+    deps = [
+        "//implementation_deps/support:lib_a",
+        "//implementation_deps/support:lib_b",
+    ],
+)
+
+cc_library(
     name = "use_complex_includes",
     srcs = ["use_complex_includes.cpp"],
     hdrs = ["use_complex_includes.h"],

--- a/test/aspect/implementation_deps/test_tag_false.py
+++ b/test/aspect/implementation_deps/test_tag_false.py
@@ -1,0 +1,14 @@
+from expected_result import ExpectedSuccess
+from test_case import TestCaseBase
+
+from test.support.result import Result
+
+
+class TestCase(TestCaseBase):
+    def execute_test_logic(self) -> Result:
+        actual = self._run_dwyu(
+            target=["//implementation_deps:superfluous_public_dep_with_tag_opt_out"],
+            aspect=self.choose_aspect("//implementation_deps:aspect.bzl%optimize_impl_deps"),
+        )
+
+        return self._check_result(actual=actual, expected=ExpectedSuccess())

--- a/test/aspect/implementation_deps/test_tag_true.py
+++ b/test/aspect/implementation_deps/test_tag_true.py
@@ -1,0 +1,15 @@
+from expected_result import ExpectedDwyuFailure, ExpectedFailure
+from test_case import TestCaseBase
+
+from test.support.result import Result
+
+
+class TestCase(TestCaseBase):
+    def execute_test_logic(self) -> Result:
+        target = "//implementation_deps:superfluous_public_dep_with_tag_opt_in"
+        expected = ExpectedFailure(
+            ExpectedDwyuFailure(target=target, deps_which_should_be_private=["//implementation_deps/support:lib_b"])
+        )
+        actual = self._run_dwyu(target=target, aspect=self.default_aspect)
+
+        return self._check_result(actual=actual, expected=expected)

--- a/test/aspect/preprocessing/fast/BUILD
+++ b/test/aspect/preprocessing/fast/BUILD
@@ -9,3 +9,14 @@ cc_binary(
         "//preprocessing/support:lib_b",
     ],
 )
+
+cc_binary(
+    name = "no_preprocessing_with_preprocessing_chosen_by_tag",
+    srcs = ["no_preprocessing.cpp"],
+    tags = ["dwyu:preprocessing_mode=fast"],
+    deps = [
+        # Unless preprocessing is disabled one of both deps will always be unused
+        "//preprocessing/support:lib_a",
+        "//preprocessing/support:lib_b",
+    ],
+)

--- a/test/aspect/preprocessing/ignore_system_includes/BUILD
+++ b/test/aspect/preprocessing/ignore_system_includes/BUILD
@@ -10,6 +10,16 @@ cc_binary(
     ],
 )
 
+cc_binary(
+    name = "use_system_lib_with_preprocessing_chosen_by_tag",
+    srcs = ["use_system_lib.cpp"],
+    tags = ["dwyu:preprocessing_mode=ignore_system_includes"],
+    deps = [
+        ":system_switch",
+        "//preprocessing/support:lib_a",
+    ],
+)
+
 cc_library(
     name = "system_switch",
     hdrs = ["system_switch.h"],

--- a/test/aspect/preprocessing/test_mode_fast_via_tag.py
+++ b/test/aspect/preprocessing/test_mode_fast_via_tag.py
@@ -1,0 +1,13 @@
+from expected_result import ExpectedSuccess
+from test_case import TestCaseBase
+
+from test.support.result import Result
+
+
+class TestCase(TestCaseBase):
+    def execute_test_logic(self) -> Result:
+        actual = self._run_dwyu(
+            target="//preprocessing/fast:no_preprocessing_with_preprocessing_chosen_by_tag", aspect=self.default_aspect
+        )
+
+        return self._check_result(actual=actual, expected=ExpectedSuccess())

--- a/test/aspect/preprocessing/test_mode_ignore_system_includes_via_tag.py
+++ b/test/aspect/preprocessing/test_mode_ignore_system_includes_via_tag.py
@@ -6,6 +6,9 @@ from test.support.result import Result
 
 class TestCase(TestCaseBase):
     def execute_test_logic(self) -> Result:
-        actual = self._run_dwyu(target="//skip_tags:ignored_by_default_behavior", aspect=self.default_aspect)
+        actual = self._run_dwyu(
+            target="//preprocessing/ignore_system_includes:use_system_lib_with_preprocessing_chosen_by_tag",
+            aspect=self.default_aspect,
+        )
 
         return self._check_result(actual=actual, expected=ExpectedSuccess())

--- a/test/aspect/skip_tags/BUILD
+++ b/test/aspect/skip_tags/BUILD
@@ -7,9 +7,16 @@ cc_library(
 
 # Inspection this with the default configuration should not fail
 cc_library(
-    name = "ignored_by_default_behavior",
+    name = "ignored_by_legacy_default_behavior",
     hdrs = ["bar.h"],
     tags = ["no-dwyu"],
+    deps = [":unused_lib"],
+)
+
+cc_library(
+    name = "ignored_by_new_tagging_syntax",
+    hdrs = ["bar.h"],
+    tags = ["dwyu:skip"],
     deps = [":unused_lib"],
 )
 

--- a/test/aspect/skip_tags/test_default_behavior.py
+++ b/test/aspect/skip_tags/test_default_behavior.py
@@ -1,0 +1,14 @@
+from expected_result import ExpectedSuccess
+from test_case import TestCaseBase
+
+from test.support.result import Result
+
+
+class TestCase(TestCaseBase):
+    def execute_test_logic(self) -> Result:
+        actual = self._run_dwyu(
+            target=["//skip_tags:ignored_by_legacy_default_behavior", "//skip_tags:ignored_by_new_tagging_syntax"],
+            aspect=self.default_aspect,
+        )
+
+        return self._check_result(actual=actual, expected=ExpectedSuccess())

--- a/test/aspect/unused_dep/BUILD
+++ b/test/aspect/unused_dep/BUILD
@@ -20,6 +20,26 @@ cc_binary(
     ],
 )
 
+cc_binary(
+    name = "unused_deps_allowed_by_tag",
+    srcs = ["main.cpp"],
+    tags = ["dwyu:report_unused_deps=False"],
+    deps = [
+        ":bar",
+        ":foo",  # unused dependency
+    ],
+)
+
+cc_binary(
+    name = "unused_deps_disallowed_by_tag",
+    srcs = ["main.cpp"],
+    tags = ["dwyu:report_unused_deps=True"],
+    deps = [
+        ":bar",
+        ":foo",  # unused dependency
+    ],
+)
+
 cc_library(
     name = "implementation_deps_lib",
     srcs = ["main.cpp"],

--- a/test/aspect/unused_dep/test_tag_false.py
+++ b/test/aspect/unused_dep/test_tag_false.py
@@ -1,0 +1,12 @@
+from expected_result import ExpectedSuccess
+from test_case import TestCaseBase
+
+from test.support.result import Result
+
+
+class TestCase(TestCaseBase):
+    def execute_test_logic(self) -> Result:
+        target = "//unused_dep:unused_deps_allowed_by_tag"
+        actual = self._run_dwyu(target=target, aspect=self.default_aspect)
+
+        return self._check_result(actual=actual, expected=ExpectedSuccess())

--- a/test/aspect/unused_dep/test_tag_true.py
+++ b/test/aspect/unused_dep/test_tag_true.py
@@ -1,0 +1,18 @@
+from expected_result import ExpectedDwyuFailure, ExpectedFailure
+from test_case import TestCaseBase
+
+from test.support.result import Result
+
+
+class TestCase(TestCaseBase):
+    def execute_test_logic(self) -> Result:
+        target = "//unused_dep:unused_deps_disallowed_by_tag"
+        expected = ExpectedFailure(ExpectedDwyuFailure(target=target, unused_public_deps=["//unused_dep:foo"]))
+        actual = self._run_dwyu(
+            target=target,
+            aspect=self.default_aspect,
+            # Disable the unused deps check globally and then activate it for the target under test via a tag
+            extra_args=["--aspects_parameters=dwyu_analysis_reports_unused_deps=False"],
+        )
+
+        return self._check_result(actual=actual, expected=expected)

--- a/test/aspect/using_transitive_dep/BUILD
+++ b/test/aspect/using_transitive_dep/BUILD
@@ -7,6 +7,20 @@ cc_binary(
     deps = [":direct_dep"],
 )
 
+cc_binary(
+    name = "main_with_tag_opt_in",
+    srcs = ["main.cpp"],
+    tags = ["dwyu:report_missing_direct_deps=True"],
+    deps = [":direct_dep"],
+)
+
+cc_binary(
+    name = "main_with_tag_opt_out",
+    srcs = ["main.cpp"],
+    tags = ["dwyu:report_missing_direct_deps=False"],
+    deps = [":direct_dep"],
+)
+
 cc_library(
     name = "transitive_usage_through_impl_deps",
     srcs = ["transitive_usage_through_impl_deps.h"],

--- a/test/aspect/using_transitive_dep/test_tag_false.py
+++ b/test/aspect/using_transitive_dep/test_tag_false.py
@@ -1,0 +1,16 @@
+from expected_result import ExpectedSuccess
+from test_case import TestCaseBase
+
+from test.support.result import Result
+
+
+class TestCase(TestCaseBase):
+    def execute_test_logic(self) -> Result:
+        target = "//using_transitive_dep:main_with_tag_opt_out"
+        actual = self._run_dwyu(
+            target=target,
+            aspect=self.default_aspect,
+            extra_args=["--aspects_parameters=dwyu_analysis_reports_missing_direct_deps=False"],
+        )
+
+        return self._check_result(actual=actual, expected=ExpectedSuccess())

--- a/test/aspect/using_transitive_dep/test_tag_true.py
+++ b/test/aspect/using_transitive_dep/test_tag_true.py
@@ -1,0 +1,28 @@
+from expected_result import ExpectedDwyuFailure, ExpectedFailure
+from test_case import TestCaseBase
+
+from test.support.result import Result
+
+
+class TestCase(TestCaseBase):
+    def execute_test_logic(self) -> Result:
+        target = "//using_transitive_dep:main_with_tag_opt_in"
+        expected = ExpectedFailure(
+            ExpectedDwyuFailure(
+                target=target,
+                invalid_includes={
+                    "using_transitive_dep/main.cpp": [
+                        "using_transitive_dep/transitive_dep_hdr.h",
+                        "using_transitive_dep/transitive_dep_src.h",
+                    ]
+                },
+            )
+        )
+        actual = self._run_dwyu(
+            target=target,
+            aspect=self.default_aspect,
+            # Disable the check for using transitive deps globally, so this can only fail as expected due to activating the check via a tag on the target.
+            extra_args=["--aspects_parameters=dwyu_analysis_reports_missing_direct_deps=False"],
+        )
+
+        return self._check_result(actual=actual, expected=expected)


### PR DESCRIPTION
The factory function allows much control over the DWYU aspect behavior. However, there can always be a case of only handful of targets in your stack requiring a special treatment.
This can be solved already by having a dedicated aspect instance per special case or simply skipping analysis on an edge case completely. Both options are cumbersome and undesired.
Thus, we enable now fine grained control of DWYU behavior per target by configuring the aspect via a target's tags.