### PR TITLE
chore: Add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+## Supported Versions
+
+DWYU uses [semantic versioning](https://semver.org/spec/v2.0.0.html) and does not maintain long-term support branches.
+Security fixes are provided only for the latest released version.
+Users are expected to update to the latest release to receive fixes.
+
+## Reporting a Vulnerability
+
+Please report vulnerabilities through GitHub issues or pull requests.
+
+Please include as much of the following as possible:
+
+- A description of the vulnerability and its potential impact.
+- Steps to reproduce, including a minimal example if possible.
+- The affected version(s).
+
+This project is maintained on a best-effort basis.
+There is no guaranteed response time, but reports will be triaged as soon as possible.


### PR DESCRIPTION
We are not using GitHub's security advisories. Our tool is not running in production systems, but is a Bazel projects hygiene tool working locally without remote connections.
If in our code there is some kind of vulnerability, we treat it as normal bug. There is no realistic risk someone can exploit a bug in DWYU. Thus, we prefer keeping our processes lean.